### PR TITLE
feat: add security-first Presidio Phase 2 text anonymizer operators

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ OBSURA_PII_BACKEND=noop
 OBSURA_PII_LANGUAGE=en
 OBSURA_PRESIDIO_MODEL=en_core_web_sm
 OBSURA_PRESIDIO_SCORE_THRESHOLD=0.35
+OBSURA_TEXT_ANONYMIZER_BACKEND=auto
 # Optional multi-language Presidio settings. Each configured language must have a
 # matching model entry. Example:
 # OBSURA_PRESIDIO_SUPPORTED_LANGUAGES=en,es
@@ -30,6 +31,8 @@ OBSURA_PRESIDIO_SUPPORTED_LANGUAGES=en
 OBSURA_PRESIDIO_MODEL_MAP={"en":"en_core_web_sm"}
 # Optional path to a vetted Presidio YAML recognizer registry.
 OBSURA_PRESIDIO_RECOGNIZERS_PATH=
+# Optional deployment secret for `mode=hash`. Must be at least 16 bytes.
+OBSURA_TEXT_HASH_SALT=
 
 # Optional runtime behavior
 # Raw source text and raw source files are no longer persisted by workflow jobs.

--- a/guide/FRONTEND_API_GUIDE.md
+++ b/guide/FRONTEND_API_GUIDE.md
@@ -25,6 +25,8 @@ Frontend expectation:
 - use `/api/v1/version` for diagnostics, environment display, and operator UI
 - use `/api/v1/version` to discover active `pii_languages` and whether
   `pii_custom_recognizers` are configured
+- use `/api/v1/version` to discover `text_anonymizer_backend` and whether
+  `text_hash_supported` is enabled on the deployment
 - do not use `/api/v1/health` as a full readiness signal
 - local development CORS allows `http://127.0.0.1:3000` and
   `http://localhost:3000` by default
@@ -320,6 +322,17 @@ Text-focused fields:
 - `semantic_label`
 - `alias_prefix`
 
+Text mode notes:
+
+- `generic` and `custom` replace the finding with explicit text
+- `semantic` replaces the finding with a label such as `[EMAIL]`
+- `mask` keeps the span length and masks every character
+- `partial_mask` keeps configured prefix/suffix visibility
+- `stable_alias` keeps repeated values internally consistent within one output
+- `redact` removes the matched text entirely
+- `hash` replaces the value with a salted hash and should only be surfaced when
+  `text_hash_supported` is true
+
 Image-focused fields:
 
 - `mode`
@@ -346,6 +359,8 @@ Stable defaults:
 - image default is now `blur`
 - image overlays do not render label text unless the frontend explicitly sends
   `overlay_label` or a placeholder-based mode
+- `hash` is deployment-gated and requires backend configuration; do not assume it
+  is always available
 
 ## 10. Recommended Frontend Client Structure
 

--- a/openapi.json
+++ b/openapi.json
@@ -5559,6 +5559,10 @@
             "type": "string",
             "title": "Pii Backend"
           },
+          "text_anonymizer_backend": {
+            "type": "string",
+            "title": "Text Anonymizer Backend"
+          },
           "pii_languages": {
             "items": {
               "type": "string"
@@ -5569,6 +5573,10 @@
           "pii_custom_recognizers": {
             "type": "boolean",
             "title": "Pii Custom Recognizers"
+          },
+          "text_hash_supported": {
+            "type": "boolean",
+            "title": "Text Hash Supported"
           },
           "ocr_available": {
             "type": "boolean",
@@ -5594,8 +5602,10 @@
           "ocr_backend",
           "face_detector_backend",
           "pii_backend",
+          "text_anonymizer_backend",
           "pii_languages",
           "pii_custom_recognizers",
+          "text_hash_supported",
           "ocr_available",
           "face_detection_available",
           "pii_available"
@@ -5857,6 +5867,8 @@
           "partial_mask",
           "stable_alias",
           "mask",
+          "redact",
+          "hash",
           "blur",
           "pixelate",
           "overlay",

--- a/postman.json
+++ b/postman.json
@@ -2606,7 +2606,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"title\": \"One-shot alias workflow\",\n  \"content\": \"customer=acme customer=acme customer=globex\",\n  \"content_type\": \"text\",\n  \"apply_builtins\": false,\n  \"exact_values\": [\n    \"acme\",\n    \"globex\"\n  ],\n  \"default_transformation\": {\n    \"mode\": \"stable_alias\",\n    \"alias_prefix\": \"CUSTOMER\"\n  },\n  \"persist_job\": false\n}",
+              "raw": "{\n  \"title\": \"One-shot hashed secret workflow\",\n  \"content\": \"token=alpha token=alpha\",\n  \"content_type\": \"text\",\n  \"apply_builtins\": false,\n  \"exact_values\": [\n    \"alpha\"\n  ],\n  \"default_transformation\": {\n    \"mode\": \"hash\"\n  },\n  \"persist_job\": false\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
 ]
 presidio = [
   "presidio-analyzer>=2.2.360; python_version < '3.14'",
+  "presidio-anonymizer>=2.2.360; python_version < '3.14'",
 ]
 
 [project.scripts]

--- a/src/obsura_api/api/routes/bulk_jobs.py
+++ b/src/obsura_api/api/routes/bulk_jobs.py
@@ -49,6 +49,7 @@ def analyze_bulk_text(
             session,
             settings,
             pii_detector=container.pii_detector,
+            text_anonymizer=container.text_anonymizer,
         ).analyze_text(payload),
     )
 
@@ -66,6 +67,7 @@ def list_bulk_jobs(
         session,
         settings,
         pii_detector=container.pii_detector,
+        text_anonymizer=container.text_anonymizer,
     ).list_bulk_jobs(pagination)
     return success_response(items, pagination=pagination_meta)
 
@@ -84,6 +86,7 @@ def get_bulk_job(
             session,
             settings,
             pii_detector=container.pii_detector,
+            text_anonymizer=container.text_anonymizer,
         ).get_bulk_job(str(bulk_id)),
     )
 
@@ -103,6 +106,7 @@ def review_bulk_job(
             session,
             settings,
             pii_detector=container.pii_detector,
+            text_anonymizer=container.text_anonymizer,
         ).review_bulk_job(str(bulk_id), payload),
     )
 
@@ -121,5 +125,6 @@ def transform_bulk_text(
             session,
             settings,
             pii_detector=container.pii_detector,
+            text_anonymizer=container.text_anonymizer,
         ).transform_text(payload),
     )

--- a/src/obsura_api/api/routes/health.py
+++ b/src/obsura_api/api/routes/health.py
@@ -71,10 +71,12 @@ def version(settings: SettingsDep, container: ContainerDep) -> ApiResponse[Servi
             ocr_backend=container.ocr_provider.name,
             face_detector_backend=container.face_detector.name,
             pii_backend=container.pii_detector.name,
+            text_anonymizer_backend=container.text_anonymizer.name,
             pii_languages=list(getattr(container.pii_detector, "supported_languages", ()) or ()),
             pii_custom_recognizers=bool(
                 getattr(container.pii_detector, "custom_recognizers_configured", False),
             ),
+            text_hash_supported=bool(getattr(container.text_anonymizer, "hash_supported", False)),
             ocr_available=container.ocr_provider.supported,
             face_detection_available=container.face_detector.supported,
             pii_available=container.pii_detector.supported,

--- a/src/obsura_api/api/routes/text_workflows.py
+++ b/src/obsura_api/api/routes/text_workflows.py
@@ -49,10 +49,18 @@ def analyze_text(
 def transform_text(
     payload: TextTransformRequest,
     session: SessionDep,
+    settings: SettingsDep,
+    container: ContainerDep,
 ) -> ApiResponse[TextTransformResponse]:
     """Transform a persisted text job after review decisions and overrides are applied."""
 
-    return success_response(TextTransformationService(session).transform_job(payload))
+    return success_response(
+        TextTransformationService(
+            session,
+            settings,
+            text_anonymizer=container.text_anonymizer,
+        ).transform_job(payload),
+    )
 
 
 @router.post("/analyze-transform", response_model=ApiResponse[TextTransformResponse])
@@ -70,7 +78,11 @@ def analyze_and_transform_text(
         pii_detector=container.pii_detector,
     )
     analysis = detector.analyze(payload)
-    transformer = TextTransformationService(session)
+    transformer = TextTransformationService(
+        session,
+        settings,
+        text_anonymizer=container.text_anonymizer,
+    )
     output_text, replacements = transformer.apply_findings(
         content=payload.content,
         findings=analysis.findings,

--- a/src/obsura_api/app.py
+++ b/src/obsura_api/app.py
@@ -30,6 +30,7 @@ from obsura_api.domain.operational import ServiceRootInfo
 from obsura_api.services.providers.faces import build_face_detector
 from obsura_api.services.providers.ocr import build_ocr_provider
 from obsura_api.services.providers.pii import build_pii_detector
+from obsura_api.services.providers.text_anonymizer import build_text_anonymizer
 from obsura_api.services.privacy import scrub_persisted_sensitive_data
 from obsura_api.services.storage import StorageService
 
@@ -141,10 +142,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     ocr_provider = build_ocr_provider(settings)
     face_detector = build_face_detector(settings)
     pii_detector = build_pii_detector(settings)
+    text_anonymizer = build_text_anonymizer(settings)
     PILImage.MAX_IMAGE_PIXELS = settings.max_image_pixels
     logger.info("Using `%s` OCR backend", ocr_provider.name)
     logger.info("Using `%s` face detector backend", face_detector.name)
     logger.info("Using `%s` PII detector backend", pii_detector.name)
+    logger.info(
+        "Using `%s` text anonymizer backend (hash supported: %s)",
+        text_anonymizer.name,
+        bool(getattr(text_anonymizer, "hash_supported", False)),
+    )
     if getattr(pii_detector, "supported_languages", ()):
         logger.info(
             "PII detector languages: %s (custom recognizers: %s)",
@@ -221,6 +228,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         ocr_provider=ocr_provider,
         face_detector=face_detector,
         pii_detector=pii_detector,
+        text_anonymizer=text_anonymizer,
     )
 
     app.include_router(api_router, prefix=settings.api_v1_prefix)

--- a/src/obsura_api/core/container.py
+++ b/src/obsura_api/core/container.py
@@ -11,6 +11,7 @@ from obsura_api.core.settings import Settings
 from obsura_api.services.providers.faces import FaceDetector
 from obsura_api.services.providers.ocr import OCRProvider
 from obsura_api.services.providers.pii import PIIDetector
+from obsura_api.services.providers.text_anonymizer import TextAnonymizer
 from obsura_api.services.storage import StorageService
 
 
@@ -25,3 +26,4 @@ class AppContainer:
     ocr_provider: OCRProvider
     face_detector: FaceDetector
     pii_detector: PIIDetector
+    text_anonymizer: TextAnonymizer

--- a/src/obsura_api/core/settings.py
+++ b/src/obsura_api/core/settings.py
@@ -114,6 +114,20 @@ class Settings(BaseSettings):
             "OBSURA_PII_RECOGNIZERS_PATH",
         ),
     )
+    text_anonymizer_backend: str = Field(
+        default="auto",
+        validation_alias=AliasChoices(
+            "OBSURA_TEXT_ANONYMIZER_BACKEND",
+            "OBSURA_PRESIDIO_ANONYMIZER_BACKEND",
+        ),
+    )
+    text_hash_salt: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "OBSURA_TEXT_HASH_SALT",
+            "OBSURA_PRESIDIO_HASH_SALT",
+        ),
+    )
     storage_root: Path = Field(default=Path("storage"))
     media_mount_path: str = "/media"
     auto_create_schema: bool = False
@@ -305,6 +319,16 @@ class Settings(BaseSettings):
             return Path(normalized)
         return value
 
+    @field_validator("text_hash_salt", mode="before")
+    @classmethod
+    def parse_text_hash_salt(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            normalized = value.strip()
+            return normalized or None
+        return value
+
     @model_validator(mode="after")
     def resolve_database_url(self) -> "Settings":
         raw_database_url = self.database_url.strip()
@@ -366,6 +390,10 @@ class Settings(BaseSettings):
                     "Presidio requires a spaCy model for each configured language. "
                     f"Missing model mapping for: {missing}",
                 )
+
+        self.text_anonymizer_backend = self.text_anonymizer_backend.strip().lower()
+        if self.text_hash_salt is not None and len(self.text_hash_salt.encode("utf-8")) < 16:
+            raise ValueError("OBSURA_TEXT_HASH_SALT must be at least 16 bytes long.")
 
         self.database_url = parsed_url.render_as_string(hide_password=False)
         return self

--- a/src/obsura_api/domain/enums.py
+++ b/src/obsura_api/domain/enums.py
@@ -31,6 +31,8 @@ class TransformationMode(str, Enum):
     PARTIAL_MASK = "partial_mask"
     STABLE_ALIAS = "stable_alias"
     MASK = "mask"
+    REDACT = "redact"
+    HASH = "hash"
     BLUR = "blur"
     PIXELATE = "pixelate"
     OVERLAY = "overlay"

--- a/src/obsura_api/domain/operational.py
+++ b/src/obsura_api/domain/operational.py
@@ -30,8 +30,10 @@ class ServiceVersionInfo(BaseModel):
     ocr_backend: str
     face_detector_backend: str
     pii_backend: str
+    text_anonymizer_backend: str
     pii_languages: list[str]
     pii_custom_recognizers: bool
+    text_hash_supported: bool
     ocr_available: bool
     face_detection_available: bool
     pii_available: bool

--- a/src/obsura_api/services/bulk_jobs.py
+++ b/src/obsura_api/services/bulk_jobs.py
@@ -36,6 +36,7 @@ from obsura_api.domain.workflows import TextTransformRequest
 from obsura_api.services.detection import TextDetectionService
 from obsura_api.services.jobs import JobService
 from obsura_api.services.providers.pii import PIIDetector, NoOpPIIDetector
+from obsura_api.services.providers.text_anonymizer import NativeTextAnonymizer, TextAnonymizer
 from obsura_api.services.text_transformations import TextTransformationService
 from obsura_api.services.utils import summarize_findings
 
@@ -191,6 +192,8 @@ class BulkJobService:
         session: Session,
         settings: Settings,
         pii_detector: PIIDetector | None = None,
+        *,
+        text_anonymizer: TextAnonymizer | None = None,
     ) -> None:
         self.session = session
         self.settings = settings
@@ -200,7 +203,12 @@ class BulkJobService:
             pii_detector=pii_detector or NoOpPIIDetector(),
         )
         self.job_service = JobService(session)
-        self.text_transformations = TextTransformationService(session)
+        self.text_transformations = TextTransformationService(
+            session,
+            settings,
+            text_anonymizer=text_anonymizer
+            or NativeTextAnonymizer(hash_salt=settings.text_hash_salt),
+        )
 
     def analyze_text(self, payload: BulkTextAnalyzeRequest) -> BulkJobRead:
         self._validate_bulk_request(payload)

--- a/src/obsura_api/services/providers/text_anonymizer.py
+++ b/src/obsura_api/services/providers/text_anonymizer.py
@@ -1,0 +1,153 @@
+"""Text anonymizer backends for safe text replacement operators."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from obsura_api.core.settings import Settings
+
+
+class TextAnonymizer(Protocol):
+    """Protocol for text anonymization backends."""
+
+    name: str
+    supported: bool
+    hash_supported: bool
+
+    def replace(self, text: str, replacement: str) -> str:
+        """Replace a text segment with a provided value."""
+
+    def mask(self, text: str, *, mask_character: str) -> str:
+        """Mask a text segment."""
+
+    def redact(self, text: str) -> str:
+        """Redact a text segment completely."""
+
+    def hash(self, text: str, *, salt: str) -> str:
+        """Hash a text segment with an explicit salt."""
+
+
+class NativeTextAnonymizer:
+    """Built-in text anonymizer that requires no optional dependencies."""
+
+    name = "native-text-anonymizer"
+    supported = True
+
+    def __init__(self, *, hash_salt: str | None = None) -> None:
+        self.hash_supported = bool(hash_salt)
+
+    def replace(self, text: str, replacement: str) -> str:
+        _ = text
+        return replacement
+
+    def mask(self, text: str, *, mask_character: str) -> str:
+        return mask_character * max(len(text), 1)
+
+    def redact(self, text: str) -> str:
+        _ = text
+        return ""
+
+    def hash(self, text: str, *, salt: str) -> str:
+        return _hash_with_salt(text, salt)
+
+
+class PresidioTextAnonymizer:
+    """Presidio-backed text anonymizer using vetted built-in operators only."""
+
+    name = "presidio-text-anonymizer"
+    supported = True
+    hash_supported = True
+
+    def __init__(self) -> None:
+        try:
+            from presidio_anonymizer import AnonymizerEngine
+            from presidio_anonymizer.entities import OperatorConfig, RecognizerResult
+        except ImportError as exc:
+            raise RuntimeError(
+                "Presidio text anonymization requires the `presidio-anonymizer` package.",
+            ) from exc
+
+        self._engine = AnonymizerEngine()
+        self._operator_config = OperatorConfig
+        self._recognizer_result = RecognizerResult
+
+    def replace(self, text: str, replacement: str) -> str:
+        return self._anonymize_segment(
+            text,
+            operator_name="replace",
+            params={"new_value": replacement},
+        )
+
+    def mask(self, text: str, *, mask_character: str) -> str:
+        return self._anonymize_segment(
+            text,
+            operator_name="mask",
+            params={
+                "masking_char": mask_character,
+                "chars_to_mask": max(len(text), 1),
+                "from_end": True,
+            },
+        )
+
+    def redact(self, text: str) -> str:
+        return self._anonymize_segment(text, operator_name="redact")
+
+    def hash(self, text: str, *, salt: str) -> str:
+        return self._anonymize_segment(
+            text,
+            operator_name="hash",
+            params={"hash_type": "sha256", "salt": salt},
+        )
+
+    def _anonymize_segment(
+        self,
+        text: str,
+        *,
+        operator_name: str,
+        params: dict[str, object] | None = None,
+    ) -> str:
+        if not text:
+            return ""
+        result = self._engine.anonymize(
+            text=text,
+            analyzer_results=[
+                self._recognizer_result(
+                    entity_type="TEXT",
+                    start=0,
+                    end=len(text),
+                    score=1.0,
+                )
+            ],
+            operators={
+                "TEXT": self._operator_config(operator_name, params or {}),
+            },
+        )
+        return result.text
+
+
+def build_text_anonymizer(settings: Settings) -> TextAnonymizer:
+    """Build the configured text anonymizer backend."""
+
+    backend = settings.text_anonymizer_backend.strip().lower()
+    if backend in {"native", "builtin", "built_in"}:
+        return NativeTextAnonymizer(hash_salt=settings.text_hash_salt)
+    if backend in {"presidio"}:
+        return PresidioTextAnonymizer()
+    if backend in {"", "auto"}:
+        try:
+            return PresidioTextAnonymizer()
+        except RuntimeError:
+            return NativeTextAnonymizer(hash_salt=settings.text_hash_salt)
+    raise RuntimeError(
+        f"Unsupported text anonymizer backend `{settings.text_anonymizer_backend}`.",
+    )
+
+
+def _hash_with_salt(text: str, salt: str) -> str:
+    digest = hashlib.sha256()
+    digest.update(salt.encode("utf-8"))
+    digest.update(b":")
+    digest.update(text.encode("utf-8"))
+    return digest.hexdigest()

--- a/src/obsura_api/services/text_transformations.py
+++ b/src/obsura_api/services/text_transformations.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
+from obsura_api.core.settings import Settings
 from obsura_api.db.models import Job, JobOutput
 from obsura_api.domain.enums import ContentType, FindingSource, JobStatus, ReviewDecision, TransformationMode
 from obsura_api.domain.transforms import TransformationRule
@@ -21,6 +22,7 @@ from obsura_api.domain.workflows import (
 )
 from obsura_api.services.jobs import finding_to_schema
 from obsura_api.services.utils import hash_value, normalize_token, summarize_findings
+from obsura_api.services.providers.text_anonymizer import NativeTextAnonymizer, TextAnonymizer
 
 
 SOURCE_PRIORITY = {
@@ -35,8 +37,18 @@ SOURCE_PRIORITY = {
 class TextTransformationService:
     """Apply approved or pending findings to text content."""
 
-    def __init__(self, session: Session) -> None:
+    def __init__(
+        self,
+        session: Session,
+        settings: Settings | None = None,
+        *,
+        text_anonymizer: TextAnonymizer | None = None,
+    ) -> None:
         self.session = session
+        self.settings = settings
+        self.text_anonymizer = text_anonymizer or NativeTextAnonymizer(
+            hash_salt=getattr(settings, "text_hash_salt", None),
+        )
 
     def transform_job(self, request: TextTransformRequest) -> TextTransformResponse:
         if not request.job_id:
@@ -237,13 +249,31 @@ class TextTransformationService:
         alias_counts: dict[str, int],
     ) -> str:
         if rule.mode is TransformationMode.SEMANTIC:
-            return f"[{normalize_token(rule.semantic_label or finding.entity_type)}]"
+            return self._replace_with_operator(
+                original_value,
+                f"[{normalize_token(rule.semantic_label or finding.entity_type)}]",
+            )
 
         if rule.mode in {TransformationMode.GENERIC, TransformationMode.CUSTOM}:
-            return rule.placeholder or "[REDACTED]"
+            return self._replace_with_operator(
+                original_value,
+                rule.placeholder or "[REDACTED]",
+            )
 
         if rule.mode is TransformationMode.MASK:
-            return rule.mask_character * max(len(original_value), 1)
+            return self.text_anonymizer.mask(
+                original_value,
+                mask_character=rule.mask_character,
+            )
+
+        if rule.mode is TransformationMode.REDACT:
+            return self.text_anonymizer.redact(original_value)
+
+        if rule.mode is TransformationMode.HASH:
+            return self.text_anonymizer.hash(
+                original_value,
+                salt=self._require_hash_salt(),
+            )
 
         if rule.mode is TransformationMode.PARTIAL_MASK:
             visible_prefix = rule.prefix_visible
@@ -270,6 +300,20 @@ class TextTransformationService:
             return alias_map[key]
 
         return rule.placeholder or f"[{normalize_token(finding.entity_type)}]"
+
+    def _replace_with_operator(self, original_value: str, replacement: str) -> str:
+        return self.text_anonymizer.replace(original_value, replacement)
+
+    def _require_hash_salt(self) -> str:
+        if self.settings is None or not self.settings.text_hash_salt:
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=(
+                    "Hash transformations require OBSURA_TEXT_HASH_SALT to be configured "
+                    "on this deployment"
+                ),
+            )
+        return self.settings.text_hash_salt
 
     def _load_text_job(self, job_id: str) -> Job:
         job = self.session.scalar(

--- a/src/obsura_api/tools/api_artifacts.py
+++ b/src/obsura_api/tools/api_artifacts.py
@@ -250,14 +250,13 @@ REQUEST_EXAMPLES: dict[tuple[str, str], dict[str, Any]] = {
         "persist_output": True,
     },
     ("POST", "/api/v1/workflows/text/analyze-transform"): {
-        "title": "One-shot alias workflow",
-        "content": "customer=acme customer=acme customer=globex",
+        "title": "One-shot hashed secret workflow",
+        "content": "token=alpha token=alpha",
         "content_type": "text",
         "apply_builtins": False,
-        "exact_values": ["acme", "globex"],
+        "exact_values": ["alpha"],
         "default_transformation": {
-            "mode": "stable_alias",
-            "alias_prefix": "CUSTOMER",
+            "mode": "hash",
         },
         "persist_job": False,
     },

--- a/tests/test_operational.py
+++ b/tests/test_operational.py
@@ -58,8 +58,10 @@ def test_ready_and_version_endpoints(client) -> None:
     assert version_body["data"]["schema_revision"] == expected_head
     assert version_body["data"]["schema_head"] == expected_head
     assert version_body["data"]["pii_backend"] == "noop-pii-detector"
+    assert version_body["data"]["text_anonymizer_backend"] == "native-text-anonymizer"
     assert version_body["data"]["pii_languages"] == []
     assert version_body["data"]["pii_custom_recognizers"] is False
+    assert version_body["data"]["text_hash_supported"] is False
     assert version_body["data"]["ocr_available"] is False
     assert version_body["data"]["face_detection_available"] is False
     assert version_body["data"]["pii_available"] is False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -47,6 +47,10 @@ def clear_settings_env(monkeypatch) -> None:
         "OBSURA_PII_MODEL_MAP",
         "OBSURA_PRESIDIO_RECOGNIZERS_PATH",
         "OBSURA_PII_RECOGNIZERS_PATH",
+        "OBSURA_TEXT_ANONYMIZER_BACKEND",
+        "OBSURA_PRESIDIO_ANONYMIZER_BACKEND",
+        "OBSURA_TEXT_HASH_SALT",
+        "OBSURA_PRESIDIO_HASH_SALT",
     ):
         monkeypatch.delenv(key, raising=False)
     get_settings.cache_clear()
@@ -173,12 +177,29 @@ def test_reads_extended_presidio_settings(monkeypatch, tmp_path: Path) -> None:
     assert settings.presidio_recognizers_path == recognizers_path
 
 
+def test_reads_text_anonymizer_settings(monkeypatch) -> None:
+    monkeypatch.setenv("OBSURA_TEXT_ANONYMIZER_BACKEND", "native")
+    monkeypatch.setenv("OBSURA_TEXT_HASH_SALT", "0123456789abcdef")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.text_anonymizer_backend == "native"
+    assert settings.text_hash_salt == "0123456789abcdef"
+
+
 def test_presidio_requires_model_for_each_configured_language(monkeypatch) -> None:
     monkeypatch.setenv("OBSURA_PII_BACKEND", "presidio")
     monkeypatch.setenv("OBSURA_PRESIDIO_SUPPORTED_LANGUAGES", "en,es")
     monkeypatch.setenv("OBSURA_PRESIDIO_MODEL_MAP", '{"en":"en_core_web_sm"}')
 
     with pytest.raises(ValidationError, match="Missing model mapping for: es"):
+        Settings(_env_file=None)
+
+
+def test_rejects_short_text_hash_salt(monkeypatch) -> None:
+    monkeypatch.setenv("OBSURA_TEXT_HASH_SALT", "short")
+
+    with pytest.raises(ValidationError, match="OBSURA_TEXT_HASH_SALT must be at least 16 bytes long"):
         Settings(_env_file=None)
 
 

--- a/tests/test_text_anonymizer.py
+++ b/tests/test_text_anonymizer.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from obsura_api.core.settings import Settings
+from obsura_api.services.providers import text_anonymizer as anonymizer_module
+from obsura_api.services.providers.text_anonymizer import build_text_anonymizer
+
+
+def test_build_text_anonymizer_uses_native_backend_when_presidio_is_unavailable(monkeypatch) -> None:
+    def raising_presidio_backend():
+        raise RuntimeError("missing package")
+
+    monkeypatch.setattr(anonymizer_module, "PresidioTextAnonymizer", raising_presidio_backend)
+    settings = Settings(text_anonymizer_backend="auto", _env_file=None)
+
+    backend = build_text_anonymizer(settings)
+
+    assert backend.name == "native-text-anonymizer"
+    assert backend.supported is True
+    assert backend.hash_supported is False
+
+
+def test_build_text_anonymizer_can_use_explicit_presidio_backend(monkeypatch) -> None:
+    class StubTextAnonymizer:
+        name = "presidio-text-anonymizer"
+        supported = True
+        hash_supported = True
+
+        def replace(self, text: str, replacement: str) -> str:
+            return replacement
+
+        def mask(self, text: str, *, mask_character: str) -> str:
+            return mask_character * len(text)
+
+        def redact(self, text: str) -> str:
+            return ""
+
+        def hash(self, text: str, *, salt: str) -> str:
+            return f"{salt}:{text}"
+
+    monkeypatch.setattr(anonymizer_module, "PresidioTextAnonymizer", StubTextAnonymizer)
+    settings = Settings(text_anonymizer_backend="presidio", _env_file=None)
+
+    backend = build_text_anonymizer(settings)
+
+    assert backend.name == "presidio-text-anonymizer"
+    assert backend.supported is True
+    assert backend.hash_supported is True
+
+
+def test_native_text_anonymizer_hashes_with_deployment_salt() -> None:
+    settings = Settings(
+        text_anonymizer_backend="native",
+        text_hash_salt="0123456789abcdef",
+        _env_file=None,
+    )
+
+    backend = build_text_anonymizer(settings)
+
+    assert backend.hash_supported is True
+    assert backend.hash(text="secret", salt=settings.text_hash_salt or "") == hashlib.sha256(
+        b"0123456789abcdef:secret",
+    ).hexdigest()
+
+
+def test_build_text_anonymizer_rejects_unknown_backend() -> None:
+    settings = Settings(text_anonymizer_backend="mystery", _env_file=None)
+
+    with pytest.raises(RuntimeError, match="Unsupported text anonymizer backend"):
+        build_text_anonymizer(settings)

--- a/tests/test_text_workflows.py
+++ b/tests/test_text_workflows.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+import hashlib
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from obsura_api.app import create_app
+from obsura_api.core.settings import Settings
+
 
 def test_text_review_and_transform_flow(client) -> None:
     pattern_response = client.post(
@@ -158,3 +166,65 @@ def test_text_transform_supports_partial_mask_for_frontend_customization(client)
     assert response.status_code == 200
     body = response.json()["data"]
     assert body["output_text"] == "Contact me at jo******@example.com"
+
+
+def test_text_transform_supports_redact_mode(client) -> None:
+    response = client.post(
+        "/api/v1/workflows/text/analyze-transform",
+        json={
+            "content": "token=supersecret",
+            "exact_values": ["supersecret"],
+            "default_transformation": {"mode": "redact"},
+            "persist_job": False,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["output_text"] == "token="
+
+
+def test_text_transform_supports_hash_mode_with_configured_salt(tmp_path: Path) -> None:
+    settings = Settings(
+        database_url=f"sqlite:///{tmp_path / 'obsura.db'}",
+        storage_root=tmp_path / "storage",
+        auto_create_schema=True,
+        ocr_backend="noop",
+        face_detector_backend="noop",
+        pii_backend="noop",
+        text_hash_salt="0123456789abcdef",
+        _env_file=None,
+    )
+    app = create_app(settings)
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/workflows/text/analyze-transform",
+            json={
+                "content": "token=alpha token=alpha",
+                "exact_values": ["alpha"],
+                "default_transformation": {"mode": "hash"},
+                "persist_job": False,
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    expected_hash = hashlib.sha256(b"0123456789abcdef:alpha").hexdigest()
+    assert body["output_text"] == f"token={expected_hash} token={expected_hash}"
+
+
+def test_text_transform_rejects_hash_mode_without_configured_salt(client) -> None:
+    response = client.post(
+        "/api/v1/workflows/text/analyze-transform",
+        json={
+            "content": "token=alpha",
+            "exact_values": ["alpha"],
+            "default_transformation": {"mode": "hash"},
+            "persist_job": False,
+        },
+    )
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["success"] is False
+    assert "OBSURA_TEXT_HASH_SALT" in body["error"]["message"]


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the Presidio integration for `obsura-api`.

Phase 1 expanded secure PII detection controls.  
Phase 2 adds a security-first text anonymization layer for transformation workflows, while preserving the existing hardened no-persistence model.

This introduces a dedicated text anonymizer backend, adds safe text operator modes, wires the backend through text and bulk workflows, and exposes anonymizer capability metadata to the frontend/admin UI.

## What changed

### 1. Added a dedicated text anonymizer backend
A new backend abstraction was added for text anonymization with:

- native fallback support
- optional Presidio Anonymizer support
- deployment-controlled capability selection

This keeps anonymization backend behavior explicit and isolated from detection logic.

### 2. Added new safe text transformation modes
Text workflows now support:

- `redact`
- `hash`

Existing modes remain supported:

- `generic`
- `custom`
- `semantic`
- `mask`
- `partial_mask`
- `stable_alias`

### 3. Preserved native handling where it is safer
Some transformations intentionally remain on the native path:

- `partial_mask`
- `stable_alias`

These behaviors depend on output-local state or deterministic prefix/suffix visibility and are safer to keep under our own implementation.

### 4. Added deployment-gated hash support
`mode=hash` now works only when `OBSURA_TEXT_HASH_SALT` is configured.

This avoids unsafe unhashed or weakly configured behavior and makes hashed anonymization an explicit deployment choice.

### 5. Wired anonymizer support through all text transform paths
The new text anonymizer backend is now used in:

- `POST /api/v1/workflows/text/transform`
- `POST /api/v1/workflows/text/analyze-transform`
- bulk text transform flows

### 6. Exposed anonymizer runtime capability metadata
`/api/v1/version` now includes:

- `text_anonymizer_backend`
- `text_hash_supported`

This allows the frontend/admin UI to conditionally expose text operator options based on deployment capabilities.

### 7. Updated config and docs
This PR also updates:

- `.env.example`
- frontend API guide
- OpenAPI spec
- Postman collection

## Security notes

This PR keeps the security-first posture intact:

- no raw source text persistence was reintroduced
- no deanonymization capability was added
- no user-defined anonymizer code/operators were introduced
- `hash` is deployment-gated and requires a configured salt
- Presidio anonymizer usage is limited to vetted built-in operators
- stable aliasing remains local to one output and is not externalized as global state

## Why this matters

This phase gives us a safer operator layer for text transformation and prepares the API/frontend for richer anonymization behavior without weakening the hardened architecture.

It unlocks the next steps:

- operator-aware frontend controls
- structured data anonymization
- future Presidio-backed structured/document workflows

## Testing

Validated with:

```bash
python -m pytest -q
```

Result:

```text
91 passed
```