### PR TITLE
feat(service-error-boundary): decouple services from api errors

### DIFF
--- a/src/obsura_api/api/responses.py
+++ b/src/obsura_api/api/responses.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from obsura_api.domain.common import ApiError, ApiResponse, PaginationMeta
+from obsura_api.domain.errors import AppError
 
 logger = logging.getLogger(__name__)
 SENSITIVE_DETAIL_KEYS = {
@@ -25,6 +26,13 @@ SENSITIVE_DETAIL_KEYS = {
     "structured_data",
     "text",
 }
+
+
+def _status_name(status_code: int) -> str:
+    member = HTTPStatus._value2member_map_.get(status_code)
+    if member is None:
+        return "http_error"
+    return member.name.lower()
 
 
 def _sanitize_details(value: Any) -> Any:
@@ -91,18 +99,25 @@ def http_exception_handler(
     """Return FastAPI HTTP exceptions in the unified error envelope."""
 
     _ = request
-    status_name = (
-        HTTPStatus(exc.status_code).name.lower()
-        if exc.status_code in HTTPStatus._value2member_map_
-        else "http_error"
-    )
     details = exc.detail if isinstance(exc.detail, (list, dict)) else None
     message = exc.detail if isinstance(exc.detail, str) else "Request failed"
     return error_response(
         status_code=exc.status_code,
-        code=status_name,
+        code=_status_name(exc.status_code),
         message=message,
         details=details,
+    )
+
+
+def app_error_handler(request: Request, exc: AppError) -> JSONResponse:
+    """Return native application errors in the unified error envelope."""
+
+    _ = request
+    return error_response(
+        status_code=exc.status_code,
+        code=exc.code,
+        message=exc.message,
+        details=exc.details,
     )
 
 

--- a/src/obsura_api/app.py
+++ b/src/obsura_api/app.py
@@ -12,6 +12,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from obsura_api import __version__
 from obsura_api.api.responses import (
+    app_error_handler,
     http_exception_handler,
     unhandled_exception_handler,
     validation_exception_handler,
@@ -26,6 +27,7 @@ from obsura_api.db.session import (
     ensure_database_schema,
     verify_database_connection,
 )
+from obsura_api.domain.errors import AppError
 from obsura_api.domain.operational import ServiceRootInfo
 from obsura_api.services.privacy import scrub_persisted_sensitive_data
 from obsura_api.services.providers.documents import build_document_extractor
@@ -216,6 +218,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    app.add_exception_handler(AppError, app_error_handler)
     app.add_exception_handler(HTTPException, http_exception_handler)
     app.add_exception_handler(StarletteHTTPException, http_exception_handler)
     app.add_exception_handler(RequestValidationError, validation_exception_handler)

--- a/src/obsura_api/domain/errors.py
+++ b/src/obsura_api/domain/errors.py
@@ -1,0 +1,70 @@
+"""Native application error types used below the API layer."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+
+
+def _status_code_to_code(status_code: int) -> str:
+    member = HTTPStatus._value2member_map_.get(status_code)
+    if member is None:
+        return "application_error"
+    return member.name.lower()
+
+
+class AppError(Exception):
+    """Base application error with HTTP-friendly metadata."""
+
+    default_status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | HTTPStatus | None = None,
+        code: str | None = None,
+        details: Any | None = None,
+    ) -> None:
+        super().__init__(message)
+        resolved_status = status_code or self.default_status_code
+        self.status_code = int(resolved_status)
+        self.code = code or _status_code_to_code(self.status_code)
+        self.message = message
+        self.details = details
+
+
+class BadRequestError(AppError):
+    """Raised when the request is structurally valid but semantically invalid."""
+
+    default_status_code = HTTPStatus.BAD_REQUEST
+
+
+class NotFoundError(AppError):
+    """Raised when a requested application resource does not exist."""
+
+    default_status_code = HTTPStatus.NOT_FOUND
+
+
+class ConflictError(AppError):
+    """Raised when the current deployment or resource state blocks the operation."""
+
+    default_status_code = HTTPStatus.CONFLICT
+
+
+class PayloadTooLargeError(AppError):
+    """Raised when a request exceeds configured safety limits."""
+
+    default_status_code = HTTPStatus(413)
+
+
+class UnsupportedMediaTypeError(AppError):
+    """Raised when an uploaded file or content type is unsupported."""
+
+    default_status_code = HTTPStatus.UNSUPPORTED_MEDIA_TYPE
+
+
+class UnprocessableContentError(AppError):
+    """Raised when safe validation fails against otherwise well-formed content."""
+
+    default_status_code = HTTPStatus(422)

--- a/src/obsura_api/services/bulk_jobs.py
+++ b/src/obsura_api/services/bulk_jobs.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
 
@@ -30,6 +29,7 @@ from obsura_api.domain.enums import (
     BulkOperationKind,
     JobStatus,
 )
+from obsura_api.domain.errors import AppError, NotFoundError, UnprocessableContentError
 from obsura_api.domain.jobs import JobReviewRequest
 from obsura_api.domain.workflows import TextTransformRequest
 from obsura_api.services.detection import TextDetectionService
@@ -387,7 +387,7 @@ class BulkJobService:
                     ),
                 )
                 success_count += 1
-            except HTTPException as exc:
+            except AppError as exc:
                 self.session.rollback()
                 items.append(
                     self._build_review_result(
@@ -463,7 +463,7 @@ class BulkJobService:
                     ),
                 )
                 success_count += 1
-            except HTTPException as exc:
+            except AppError as exc:
                 self.session.rollback()
                 items.append(
                     self._build_transform_result(
@@ -607,7 +607,7 @@ class BulkJobService:
             ),
         )
         if bulk_job is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Bulk job not found")
+            raise NotFoundError("Bulk job not found")
         return bulk_job
 
     def _load_bulk_item(self, item_id: str) -> BulkJobItem:
@@ -621,7 +621,7 @@ class BulkJobService:
             ),
         )
         if item is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Bulk job item not found")
+            raise NotFoundError("Bulk job item not found")
         return item
 
     def _snapshot_items(self, bulk_job: BulkJob) -> list[BulkItemSnapshot]:
@@ -638,21 +638,15 @@ class BulkJobService:
 
     def _validate_bulk_request(self, payload: BulkTextAnalyzeRequest) -> None:
         if len(payload.items) > self.settings.max_bulk_text_items:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=(
-                    "Bulk request exceeds the configured maximum of "
-                    f"{self.settings.max_bulk_text_items} items"
-                ),
+            raise UnprocessableContentError(
+                "Bulk request exceeds the configured maximum of "
+                f"{self.settings.max_bulk_text_items} items",
             )
         total_characters = sum(len(item.content or "") for item in payload.items)
         if total_characters > self.settings.max_bulk_text_total_characters:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=(
-                    "Bulk request exceeds the configured maximum combined content size of "
-                    f"{self.settings.max_bulk_text_total_characters} characters"
-                ),
+            raise UnprocessableContentError(
+                "Bulk request exceeds the configured maximum combined content size of "
+                f"{self.settings.max_bulk_text_total_characters} characters",
             )
 
     def _validate_bulk_review_targets(
@@ -664,9 +658,8 @@ class BulkJobService:
         invalid_job_ids = [job_id for job_id in entries_by_job_id if job_id not in allowed_job_ids]
         if invalid_job_ids:
             invalid_label = ", ".join(invalid_job_ids)
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=f"Bulk review entries must reference jobs in this bulk run: {invalid_label}",
+            raise UnprocessableContentError(
+                f"Bulk review entries must reference jobs in this bulk run: {invalid_label}",
             )
 
     def _validate_bulk_transform_targets(
@@ -680,10 +673,9 @@ class BulkJobService:
         ]
         if invalid_job_ids:
             invalid_label = ", ".join(invalid_job_ids)
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=f"Bulk transform overrides must reference jobs in this bulk run: {invalid_label}",
+            raise UnprocessableContentError(
+                f"Bulk transform overrides must reference jobs in this bulk run: {invalid_label}",
             )
 
-    def _error_message(self, exc: HTTPException) -> str:
-        return exc.detail if isinstance(exc.detail, str) else "Bulk operation failed"
+    def _error_message(self, exc: AppError) -> str:
+        return exc.message or "Bulk operation failed"

--- a/src/obsura_api/services/csv_workflows.py
+++ b/src/obsura_api/services/csv_workflows.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
 
-from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from obsura_api.core.settings import Settings
@@ -20,6 +19,13 @@ from obsura_api.domain.csv_workflows import (
     CSVWorkflowResponse,
 )
 from obsura_api.domain.enums import ContentType, FindingKind, JobStatus
+from obsura_api.domain.errors import (
+    BadRequestError,
+    NotFoundError,
+    PayloadTooLargeError,
+    UnprocessableContentError,
+    UnsupportedMediaTypeError,
+)
 from obsura_api.domain.pii import PIIDetectionOptions
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingOverride, FindingRecord
@@ -183,12 +189,9 @@ class CSVWorkflowService:
         _ = filename
         job = self.session.get(Job, request.job_id)
         if job is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+            raise NotFoundError("Job not found")
         if job.content_type is not ContentType.CSV:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Only CSV jobs can be transformed with this endpoint",
-            )
+            raise BadRequestError("Only CSV jobs can be transformed with this endpoint")
 
         csv_metadata = self._csv_job_metadata(job.findings)
         parsed = self._parse_csv(
@@ -304,46 +307,31 @@ class CSVWorkflowService:
         )
         raw_rows = [list(row) for row in reader]
         if not raw_rows:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Uploaded CSV is empty",
-            )
+            raise BadRequestError("Uploaded CSV is empty")
         if len(raw_rows) > self.settings.max_csv_rows:
-            raise HTTPException(
-                status.HTTP_413_CONTENT_TOO_LARGE,
-                detail=(
-                    f"CSV exceeds the configured maximum row count of {self.settings.max_csv_rows}"
-                ),
+            raise PayloadTooLargeError(
+                f"CSV exceeds the configured maximum row count of {self.settings.max_csv_rows}",
             )
         column_count = max((len(row) for row in raw_rows), default=0)
         if column_count > self.settings.max_csv_columns:
-            raise HTTPException(
-                status.HTTP_413_CONTENT_TOO_LARGE,
-                detail=(
-                    "CSV exceeds the configured maximum column count of "
-                    f"{self.settings.max_csv_columns}"
-                ),
+            raise PayloadTooLargeError(
+                "CSV exceeds the configured maximum column count of "
+                f"{self.settings.max_csv_columns}",
             )
 
         total_characters = 0
         for row in raw_rows:
             for cell in row:
                 if len(cell) > self.settings.max_bulk_text_item_characters:
-                    raise HTTPException(
-                        status.HTTP_413_CONTENT_TOO_LARGE,
-                        detail=(
-                            "CSV cell exceeds the configured maximum of "
-                            f"{self.settings.max_bulk_text_item_characters} characters"
-                        ),
+                    raise PayloadTooLargeError(
+                        "CSV cell exceeds the configured maximum of "
+                        f"{self.settings.max_bulk_text_item_characters} characters",
                     )
                 total_characters += len(cell)
                 if total_characters > self.settings.max_csv_characters:
-                    raise HTTPException(
-                        status.HTTP_413_CONTENT_TOO_LARGE,
-                        detail=(
-                            "CSV exceeds the configured maximum character count of "
-                            f"{self.settings.max_csv_characters}"
-                        ),
+                    raise PayloadTooLargeError(
+                        "CSV exceeds the configured maximum character count of "
+                        f"{self.settings.max_csv_characters}",
                     )
 
         header_row = raw_rows[0] if has_header else []
@@ -439,9 +427,8 @@ class CSVWorkflowService:
             current_hash = self._csv_cell_hash(finding)
             existing_hash = cell_hashes.get(key)
             if existing_hash is not None and existing_hash != current_hash:
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail="Stored CSV finding metadata is internally inconsistent",
+                raise UnprocessableContentError(
+                    "Stored CSV finding metadata is internally inconsistent",
                 )
             cell_hashes[key] = current_hash
             column_names[key] = self._csv_column_name(finding)
@@ -454,31 +441,24 @@ class CSVWorkflowService:
         for (physical_row_number, column_index), cell_findings in findings_by_cell.items():
             row_index = row_map.get(physical_row_number)
             if row_index is None:
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail=f"Resubmitted CSV is missing reviewed row {physical_row_number}",
+                raise UnprocessableContentError(
+                    f"Resubmitted CSV is missing reviewed row {physical_row_number}",
                 )
             row = output_rows[row_index]
             column_offset = column_index - 1
             if column_offset >= len(row):
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail=(
-                        "Resubmitted CSV is missing the reviewed cell at row "
-                        f"{physical_row_number}, column {column_index}"
-                    ),
+                raise UnprocessableContentError(
+                    "Resubmitted CSV is missing the reviewed cell at row "
+                    f"{physical_row_number}, column {column_index}",
                 )
             original_value = row[column_offset]
             if (
                 validate_cell_hash
                 and hash_value(original_value) != cell_hashes[(physical_row_number, column_index)]
             ):
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail=(
-                        "Resubmitted CSV cell content does not match the reviewed job at row "
-                        f"{physical_row_number}, column {column_index}"
-                    ),
+                raise UnprocessableContentError(
+                    "Resubmitted CSV cell content does not match the reviewed job at row "
+                    f"{physical_row_number}, column {column_index}",
                 )
 
             output_value, cell_replacements = self.text_transformations.apply_findings(
@@ -551,17 +531,11 @@ class CSVWorkflowService:
 
     def _decode_csv(self, file_bytes: bytes) -> str:
         if not file_bytes:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Uploaded CSV is empty",
-            )
+            raise BadRequestError("Uploaded CSV is empty")
         try:
             return file_bytes.decode("utf-8-sig")
         except UnicodeDecodeError as exc:
-            raise HTTPException(
-                status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-                detail="CSV uploads must be UTF-8 or UTF-8 with BOM",
-            ) from exc
+            raise UnsupportedMediaTypeError("CSV uploads must be UTF-8 or UTF-8 with BOM") from exc
 
     def _resolve_headers(self, row: list[str], column_count: int, has_header: bool) -> list[str]:
         if not has_header:
@@ -582,10 +556,7 @@ class CSVWorkflowService:
 
     def _csv_job_metadata(self, findings: list[JobFinding]) -> dict[str, object]:
         if not findings:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="CSV job has no persisted findings to transform",
-            )
+            raise UnprocessableContentError("CSV job has no persisted findings to transform")
         metadata = findings[0].extra_data
         has_header = metadata.get("csv_has_header")
         delimiter = metadata.get("csv_delimiter")
@@ -595,16 +566,10 @@ class CSVWorkflowService:
             or not isinstance(delimiter, str)
             or not isinstance(quotechar, str)
         ):
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="CSV job is missing safe format metadata",
-            )
+            raise UnprocessableContentError("CSV job is missing safe format metadata")
         resolved_delimiter = "\t" if delimiter == "\\t" else delimiter
         if resolved_delimiter not in {",", ";", "\t"} or len(quotechar) != 1:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="CSV job contains unsupported format metadata",
-            )
+            raise UnprocessableContentError("CSV job contains unsupported format metadata")
         return {
             "has_header": has_header,
             "delimiter": resolved_delimiter,
@@ -614,37 +579,25 @@ class CSVWorkflowService:
     def _csv_row_number(self, finding: FindingRecord) -> int:
         value = finding.metadata.get("csv_row_number")
         if not isinstance(value, int) or value < 1:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="CSV finding is missing safe row metadata",
-            )
+            raise UnprocessableContentError("CSV finding is missing safe row metadata")
         return value
 
     def _csv_column_index(self, finding: FindingRecord) -> int:
         value = finding.metadata.get("csv_column_index")
         if not isinstance(value, int) or value < 1:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="CSV finding is missing safe column metadata",
-            )
+            raise UnprocessableContentError("CSV finding is missing safe column metadata")
         return value
 
     def _csv_column_name(self, finding: FindingRecord) -> str:
         value = finding.metadata.get("csv_column_name")
         if not isinstance(value, str) or not value:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="CSV finding is missing safe column metadata",
-            )
+            raise UnprocessableContentError("CSV finding is missing safe column metadata")
         return value
 
     def _csv_cell_hash(self, finding: FindingRecord) -> str:
         value = finding.metadata.get("csv_cell_hash")
         if not isinstance(value, str) or not value:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="CSV finding is missing safe cell hash metadata",
-            )
+            raise UnprocessableContentError("CSV finding is missing safe cell hash metadata")
         return value
 
     def _apply_override(
@@ -656,10 +609,7 @@ class CSVWorkflowService:
             return
         finding = stored_findings.get(override.finding_id)
         if finding is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND,
-                detail=f"Finding {override.finding_id} not found",
-            )
+            raise NotFoundError(f"Finding {override.finding_id} not found")
         if override.decision is not None:
             finding.decision = override.decision
         if override.transformation is not None:

--- a/src/obsura_api/services/detection.py
+++ b/src/obsura_api/services/detection.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from fastapi import HTTPException, status
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
@@ -19,6 +18,7 @@ from obsura_api.domain.enums import (
     MatcherKind,
     TransformationMode,
 )
+from obsura_api.domain.errors import PayloadTooLargeError, UnprocessableContentError
 from obsura_api.domain.pii import PIIDetectionOptions, merge_pii_detection_options
 from obsura_api.domain.studio import PatternMatcherDefinition
 from obsura_api.domain.transforms import TransformationRule
@@ -229,12 +229,9 @@ class TextDetectionService:
     def _validate_content_size(self, content: str) -> None:
         if len(content) <= self.settings.max_bulk_text_item_characters:
             return
-        raise HTTPException(
-            status.HTTP_413_CONTENT_TOO_LARGE,
-            detail=(
-                "Text content exceeds the configured maximum of "
-                f"{self.settings.max_bulk_text_item_characters} characters"
-            ),
+        raise PayloadTooLargeError(
+            "Text content exceeds the configured maximum of "
+            f"{self.settings.max_bulk_text_item_characters} characters",
         )
 
     def build_findings(
@@ -485,7 +482,7 @@ class TextDetectionService:
         except TypeError:
             detected_entities = self.pii_detector.detect_entities(text)
         except ValueError as exc:
-            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+            raise UnprocessableContentError(str(exc)) from exc
 
         for entity in detected_entities:
             if self._overlaps_existing_span(entity, existing_findings):
@@ -527,12 +524,9 @@ class TextDetectionService:
             and resolved.language not in supported_languages
         ):
             supported = ", ".join(supported_languages)
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=(
-                    f"Unsupported PII language `{resolved.language}` for this deployment. "
-                    f"Supported languages: {supported}"
-                ),
+            raise UnprocessableContentError(
+                f"Unsupported PII language `{resolved.language}` for this deployment. "
+                f"Supported languages: {supported}",
             )
         return resolved
 
@@ -546,9 +540,8 @@ class TextDetectionService:
             configuration_name = getattr(
                 configuration, "name", getattr(configuration, "id", "configuration")
             )
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Configuration `{configuration_name}` has invalid `pii_detection` settings",
+            raise UnprocessableContentError(
+                f"Configuration `{configuration_name}` has invalid `pii_detection` settings",
             ) from exc
 
     def _detect_matcher(

--- a/src/obsura_api/services/document_workflows.py
+++ b/src/obsura_api/services/document_workflows.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
-from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from obsura_api.core.settings import Settings
@@ -19,6 +18,12 @@ from obsura_api.domain.documents import (
     DocumentWorkflowResponse,
 )
 from obsura_api.domain.enums import ContentType, JobStatus
+from obsura_api.domain.errors import (
+    BadRequestError,
+    ConflictError,
+    NotFoundError,
+    UnprocessableContentError,
+)
 from obsura_api.domain.pii import PIIDetectionOptions
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingOverride, FindingRecord
@@ -168,12 +173,9 @@ class DocumentWorkflowService:
         document = self._extract_document(file_bytes)
         job = self.session.get(Job, request.job_id)
         if job is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+            raise NotFoundError("Job not found")
         if job.content_type is not ContentType.DOCUMENT:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Only document jobs can be transformed with this endpoint",
-            )
+            raise BadRequestError("Only document jobs can be transformed with this endpoint")
 
         stored_findings = {item.id: item for item in job.findings}
         for override in request.finding_overrides:
@@ -304,9 +306,8 @@ class DocumentWorkflowService:
             page_hash = self._document_page_hash(finding)
             existing_hash = page_hashes.get(page_number)
             if existing_hash is not None and existing_hash != page_hash:
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail="Stored document finding metadata is internally inconsistent",
+                raise UnprocessableContentError(
+                    "Stored document finding metadata is internally inconsistent",
                 )
             page_hashes[page_number] = page_hash
 
@@ -320,12 +321,9 @@ class DocumentWorkflowService:
                 expected_hash = page_hashes[page.page_number]
                 actual_hash = hash_value(page.text)
                 if actual_hash != expected_hash:
-                    raise HTTPException(
-                        status.HTTP_422_UNPROCESSABLE_CONTENT,
-                        detail=(
-                            "Resubmitted PDF page content does not match the reviewed job for "
-                            f"page {page.page_number}"
-                        ),
+                    raise UnprocessableContentError(
+                        "Resubmitted PDF page content does not match the reviewed job for "
+                        f"page {page.page_number}",
                     )
 
             output_text, page_replacements = self.text_transformations.apply_findings(
@@ -357,9 +355,8 @@ class DocumentWorkflowService:
         missing_pages = sorted(set(findings_by_page) - set(page_lookup))
         if missing_pages:
             missing = ", ".join(str(page_number) for page_number in missing_pages)
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=f"Resubmitted PDF is missing reviewed pages: {missing}",
+            raise UnprocessableContentError(
+                f"Resubmitted PDF is missing reviewed pages: {missing}",
             )
 
         return page_results, self._combine_page_output(page_results), replacements
@@ -378,28 +375,19 @@ class DocumentWorkflowService:
 
     def _extract_document(self, file_bytes: bytes) -> ExtractedDocument:
         if not self.document_extractor.supported:
-            raise HTTPException(
-                status.HTTP_409_CONFLICT,
-                detail="PDF document workflows are not configured for this deployment",
-            )
+            raise ConflictError("PDF document workflows are not configured for this deployment")
         return self.document_extractor.extract_pdf(file_bytes)
 
     def _document_page_number(self, finding: FindingRecord) -> int:
         page_number = finding.metadata.get("document_page_number")
         if not isinstance(page_number, int) or page_number < 1:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="Document finding is missing safe page metadata",
-            )
+            raise UnprocessableContentError("Document finding is missing safe page metadata")
         return page_number
 
     def _document_page_hash(self, finding: FindingRecord) -> str:
         page_hash = finding.metadata.get("document_page_text_hash")
         if not isinstance(page_hash, str) or not page_hash:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="Document finding is missing safe page hash metadata",
-            )
+            raise UnprocessableContentError("Document finding is missing safe page hash metadata")
         return page_hash
 
     def _apply_override(
@@ -411,10 +399,7 @@ class DocumentWorkflowService:
             return
         finding = stored_findings.get(override.finding_id)
         if finding is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND,
-                detail=f"Finding {override.finding_id} not found",
-            )
+            raise NotFoundError(f"Finding {override.finding_id} not found")
         if override.decision is not None:
             finding.decision = override.decision
         if override.transformation is not None:

--- a/src/obsura_api/services/image_workflows.py
+++ b/src/obsura_api/services/image_workflows.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from io import BytesIO
 from typing import Iterable
 
-from fastapi import HTTPException, status
 from PIL import Image, ImageDraw, ImageFilter, ImageFont, ImageOps, UnidentifiedImageError
 from sqlalchemy.orm import Session
 
@@ -23,6 +22,15 @@ from obsura_api.domain.enums import (
     OverlayShape,
     ReviewDecision,
     TransformationMode,
+)
+from obsura_api.domain.errors import (
+    AppError,
+    BadRequestError,
+    ConflictError,
+    NotFoundError,
+    PayloadTooLargeError,
+    UnprocessableContentError,
+    UnsupportedMediaTypeError,
 )
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import (
@@ -163,16 +171,14 @@ class ImageWorkflowService:
 
         job = self.session.get(Job, request.job_id)
         if job is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+            raise NotFoundError("Job not found")
         if job.content_type not in {ContentType.IMAGE, ContentType.SCREENSHOT}:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Only image and screenshot jobs can be transformed with this endpoint",
+            raise BadRequestError(
+                "Only image and screenshot jobs can be transformed with this endpoint",
             )
         if not job.source_file_path:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Job does not retain a source image; resubmit the file to transform it",
+            raise BadRequestError(
+                "Job does not retain a source image; resubmit the file to transform it",
             )
 
         stored_findings = {item.id: item for item in job.findings}
@@ -182,15 +188,9 @@ class ImageWorkflowService:
         try:
             file_bytes = self.storage.read_stored_bytes(job.source_file_path)
         except FileNotFoundError as exc:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND,
-                detail="Stored source image was not found for this job",
-            ) from exc
+            raise NotFoundError("Stored source image was not found for this job") from exc
         except ValueError as exc:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail=str(exc),
-            ) from exc
+            raise BadRequestError(str(exc)) from exc
 
         image = self._sanitize_image_payload(file_bytes).image
         findings = [finding_to_schema(item) for item in job.findings]
@@ -271,9 +271,8 @@ class ImageWorkflowService:
 
         if manifest.detect_faces:
             if not self.face_detector.supported:
-                raise HTTPException(
-                    status.HTTP_409_CONFLICT,
-                    detail="Automatic face detection is not configured for this deployment",
+                raise ConflictError(
+                    "Automatic face detection is not configured for this deployment"
                 )
             for face in self.face_detector.detect_faces(file_bytes):
                 findings.append(
@@ -327,10 +326,7 @@ class ImageWorkflowService:
         default_transformation: TransformationRule | None,
     ) -> list[FindingRecord]:
         if not self.ocr_provider.supported:
-            raise HTTPException(
-                status.HTTP_409_CONFLICT,
-                detail="Automatic OCR is not configured for this deployment",
-            )
+            raise ConflictError("Automatic OCR is not configured for this deployment")
 
         ocr_blocks = self.ocr_provider.extract_text(file_bytes)
         patterns, entities, text_default_transformation, pii_detection = (
@@ -444,23 +440,16 @@ class ImageWorkflowService:
             with Image.open(BytesIO(file_bytes)) as opened:
                 image_format = (opened.format or "").upper()
                 if image_format not in SUPPORTED_IMAGE_FORMATS:
-                    raise HTTPException(
-                        status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-                        detail="Uploaded file is not a supported image format",
+                    raise UnsupportedMediaTypeError(
+                        "Uploaded file is not a supported image format",
                     )
                 if getattr(opened, "n_frames", 1) != 1:
-                    raise HTTPException(
-                        status.HTTP_400_BAD_REQUEST,
-                        detail="Animated or multi-frame images are not supported",
-                    )
+                    raise BadRequestError("Animated or multi-frame images are not supported")
                 width, height = opened.size
                 if width * height > self.settings.max_image_pixels:
-                    raise HTTPException(
-                        status.HTTP_413_CONTENT_TOO_LARGE,
-                        detail=(
-                            "Image exceeds the configured pixel limit of "
-                            f"{self.settings.max_image_pixels}"
-                        ),
+                    raise PayloadTooLargeError(
+                        "Image exceeds the configured pixel limit of "
+                        f"{self.settings.max_image_pixels}",
                     )
                 opened.verify()
 
@@ -468,23 +457,14 @@ class ImageWorkflowService:
                 normalized = ImageOps.exif_transpose(opened)
                 normalized.load()
                 image = normalized.convert("RGB")
-        except HTTPException:
+        except AppError:
             raise
         except Image.DecompressionBombError as exc:
-            raise HTTPException(
-                status.HTTP_413_CONTENT_TOO_LARGE,
-                detail="Image is too large to process safely",
-            ) from exc
+            raise PayloadTooLargeError("Image is too large to process safely") from exc
         except UnidentifiedImageError as exc:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Uploaded file is not a valid image",
-            ) from exc
+            raise BadRequestError("Uploaded file is not a valid image") from exc
         except OSError as exc:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Uploaded image could not be processed",
-            ) from exc
+            raise BadRequestError("Uploaded image could not be processed") from exc
 
         suffix = f".{self.storage.output_extension}"
         return SanitizedImagePayload(
@@ -499,23 +479,14 @@ class ImageWorkflowService:
             with Image.open(BytesIO(file_bytes)) as opened:
                 opened.load()
                 return opened.convert("RGB")
-        except HTTPException:
+        except AppError:
             raise
         except Image.DecompressionBombError as exc:
-            raise HTTPException(
-                status.HTTP_413_CONTENT_TOO_LARGE,
-                detail="Image is too large to process safely",
-            ) from exc
+            raise PayloadTooLargeError("Image is too large to process safely") from exc
         except UnidentifiedImageError as exc:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Uploaded file is not a valid image",
-            ) from exc
+            raise BadRequestError("Uploaded file is not a valid image") from exc
         except OSError as exc:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Uploaded image could not be processed",
-            ) from exc
+            raise BadRequestError("Uploaded image could not be processed") from exc
 
     def _validate_findings_within_bounds(
         self,
@@ -534,12 +505,8 @@ class ImageWorkflowService:
     ) -> None:
         image_width, image_height = image_size
         if region.x + region.width > image_width or region.y + region.height > image_height:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=(
-                    "Image region is outside the uploaded image bounds "
-                    f"({image_width}x{image_height})"
-                ),
+            raise UnprocessableContentError(
+                f"Image region is outside the uploaded image bounds ({image_width}x{image_height})",
             )
 
     def _should_persist_source_file(self, manifest: ImageWorkflowManifest) -> bool:
@@ -757,10 +724,7 @@ class ImageWorkflowService:
     ) -> None:
         finding = stored_findings.get(override.finding_id)
         if finding is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND,
-                detail=f"Finding {override.finding_id} not found",
-            )
+            raise NotFoundError(f"Finding {override.finding_id} not found")
         if override.decision is not None:
             finding.decision = override.decision
         if override.transformation is not None:

--- a/src/obsura_api/services/jobs.py
+++ b/src/obsura_api/services/jobs.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
 
@@ -14,6 +13,7 @@ from obsura_api.domain.common import (
     build_pagination_meta,
 )
 from obsura_api.domain.enums import JobStatus
+from obsura_api.domain.errors import NotFoundError
 from obsura_api.domain.jobs import JobOutputRecord, JobRead, JobReviewRequest
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingRecord
@@ -144,10 +144,7 @@ class JobService:
         for decision in payload.decisions:
             finding = by_id.get(decision.finding_id)
             if finding is None:
-                raise HTTPException(
-                    status.HTTP_404_NOT_FOUND,
-                    detail=f"Finding {decision.finding_id} not found",
-                )
+                raise NotFoundError(f"Finding {decision.finding_id} not found")
             finding.decision = decision.decision
             if decision.transformation is not None:
                 finding.transformation = decision.transformation.model_dump()
@@ -167,5 +164,5 @@ class JobService:
             .options(selectinload(Job.findings), selectinload(Job.outputs)),
         )
         if job is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+            raise NotFoundError("Job not found")
         return job

--- a/src/obsura_api/services/providers/documents.py
+++ b/src/obsura_api/services/providers/documents.py
@@ -6,10 +6,14 @@ from dataclasses import dataclass
 from io import BytesIO
 from typing import TYPE_CHECKING, Protocol
 
-from fastapi import HTTPException, status
-
 if TYPE_CHECKING:
     from obsura_api.core.settings import Settings
+
+from obsura_api.domain.errors import (
+    BadRequestError,
+    PayloadTooLargeError,
+    UnprocessableContentError,
+)
 
 
 @dataclass(slots=True)
@@ -83,30 +87,20 @@ class PypdfDocumentExtractor:
 
     def extract_pdf(self, pdf_bytes: bytes) -> ExtractedDocument:
         if not pdf_bytes.startswith(b"%PDF-"):
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Uploaded file is not a valid PDF document",
-            )
+            raise BadRequestError("Uploaded file is not a valid PDF document")
 
         try:
             reader = self.pdf_reader_class(BytesIO(pdf_bytes), strict=True)
         except self.pdf_read_error as exc:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Uploaded PDF could not be parsed safely",
-            ) from exc
+            raise BadRequestError("Uploaded PDF could not be parsed safely") from exc
 
         if reader.is_encrypted:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Encrypted PDF documents are not supported",
-            )
+            raise BadRequestError("Encrypted PDF documents are not supported")
 
         page_count = len(reader.pages)
         if page_count > self.max_pages:
-            raise HTTPException(
-                status.HTTP_413_CONTENT_TOO_LARGE,
-                detail=(f"PDF exceeds the configured maximum page count of {self.max_pages}"),
+            raise PayloadTooLargeError(
+                f"PDF exceeds the configured maximum page count of {self.max_pages}",
             )
 
         pages: list[ExtractedDocumentPage] = []
@@ -116,12 +110,9 @@ class PypdfDocumentExtractor:
             normalized_text = self._normalize_text(extracted_text)
             total_characters += len(normalized_text)
             if total_characters > self.max_extracted_characters:
-                raise HTTPException(
-                    status.HTTP_413_CONTENT_TOO_LARGE,
-                    detail=(
-                        "Extracted PDF text exceeds the configured maximum of "
-                        f"{self.max_extracted_characters} characters"
-                    ),
+                raise PayloadTooLargeError(
+                    "Extracted PDF text exceeds the configured maximum of "
+                    f"{self.max_extracted_characters} characters",
                 )
             pages.append(
                 ExtractedDocumentPage(
@@ -131,12 +122,9 @@ class PypdfDocumentExtractor:
             )
 
         if not any(page.text.strip() for page in pages):
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=(
-                    "PDF did not contain extractable text. Scanned or image-only PDFs "
-                    "are not supported yet"
-                ),
+            raise UnprocessableContentError(
+                "PDF did not contain extractable text. Scanned or image-only PDFs "
+                "are not supported yet",
             )
 
         return ExtractedDocument(pages=pages)

--- a/src/obsura_api/services/search.py
+++ b/src/obsura_api/services/search.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -14,6 +13,7 @@ from obsura_api.domain.common import (
     build_pagination_meta,
 )
 from obsura_api.domain.enums import SearchResultKind
+from obsura_api.domain.errors import UnprocessableContentError
 
 
 class SearchService:
@@ -28,10 +28,7 @@ class SearchService:
         pagination: PaginationParams,
     ) -> tuple[list[SearchResultItem], PaginationMeta]:
         if not query:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="Search query must not be blank",
-            )
+            raise UnprocessableContentError("Search query must not be blank")
         normalized = f"%{query.lower()}%"
         results: list[SearchResultItem] = []
 

--- a/src/obsura_api/services/structured_workflows.py
+++ b/src/obsura_api/services/structured_workflows.py
@@ -9,12 +9,17 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
 
-from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from obsura_api.core.settings import Settings
 from obsura_api.db.models import Job, JobOutput
 from obsura_api.domain.enums import ContentType, FindingKind, JobStatus
+from obsura_api.domain.errors import (
+    BadRequestError,
+    NotFoundError,
+    PayloadTooLargeError,
+    UnprocessableContentError,
+)
 from obsura_api.domain.pii import PIIDetectionOptions
 from obsura_api.domain.structured import (
     StructuredAnalysisRequest,
@@ -151,12 +156,9 @@ class StructuredWorkflowService:
         self._validate_payload_limits(request.data)
         job = self.session.get(Job, request.job_id)
         if job is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+            raise NotFoundError("Job not found")
         if job.content_type is not ContentType.STRUCTURED_TEXT:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Only structured text jobs can be transformed with this endpoint",
-            )
+            raise BadRequestError("Only structured text jobs can be transformed with this endpoint")
 
         stored_findings = {item.id: item for item in job.findings}
         for override in request.finding_overrides:
@@ -283,30 +285,23 @@ class StructuredWorkflowService:
         stats: StructuredPayloadStats,
     ) -> None:
         if depth > self.settings.max_structured_payload_depth:
-            raise HTTPException(
-                status.HTTP_413_CONTENT_TOO_LARGE,
-                detail=(
-                    "Structured payload exceeds the configured maximum depth of "
-                    f"{self.settings.max_structured_payload_depth}"
-                ),
+            raise PayloadTooLargeError(
+                "Structured payload exceeds the configured maximum depth of "
+                f"{self.settings.max_structured_payload_depth}",
             )
         stats.node_count += 1
         if stats.node_count > self.settings.max_structured_payload_nodes:
-            raise HTTPException(
-                status.HTTP_413_CONTENT_TOO_LARGE,
-                detail=(
-                    "Structured payload exceeds the configured maximum node count of "
-                    f"{self.settings.max_structured_payload_nodes}"
-                ),
+            raise PayloadTooLargeError(
+                "Structured payload exceeds the configured maximum node count of "
+                f"{self.settings.max_structured_payload_nodes}",
             )
 
         if value is None or isinstance(value, (bool, int)):
             return
         if isinstance(value, float):
             if not math.isfinite(value):
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail="Structured JSON values must not contain NaN or Infinity",
+                raise UnprocessableContentError(
+                    "Structured JSON values must not contain NaN or Infinity",
                 )
             return
         if isinstance(value, str):
@@ -323,20 +318,16 @@ class StructuredWorkflowService:
                 self._assert_character_limit(stats)
                 self._walk_payload(item, depth=depth + 1, stats=stats)
             return
-        raise HTTPException(
-            status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="Structured workflows only support JSON-compatible objects and arrays",
+        raise UnprocessableContentError(
+            "Structured workflows only support JSON-compatible objects and arrays",
         )
 
     def _assert_character_limit(self, stats: StructuredPayloadStats) -> None:
         if stats.total_characters <= self.settings.max_structured_payload_characters:
             return
-        raise HTTPException(
-            status.HTTP_413_CONTENT_TOO_LARGE,
-            detail=(
-                "Structured payload exceeds the configured total character limit of "
-                f"{self.settings.max_structured_payload_characters}"
-            ),
+        raise PayloadTooLargeError(
+            "Structured payload exceeds the configured total character limit of "
+            f"{self.settings.max_structured_payload_characters}",
         )
 
     def _iter_string_leaves(
@@ -384,17 +375,13 @@ class StructuredWorkflowService:
                 try:
                     tokens.append(int(item[2:]))
                 except ValueError as exc:
-                    raise HTTPException(
-                        status.HTTP_422_UNPROCESSABLE_CONTENT,
-                        detail="Stored structured path metadata is invalid",
+                    raise UnprocessableContentError(
+                        "Stored structured path metadata is invalid",
                     ) from exc
             elif item.startswith("s:"):
                 tokens.append(item[2:])
             else:
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail="Stored structured path metadata is invalid",
-                )
+                raise UnprocessableContentError("Stored structured path metadata is invalid")
         return tuple(tokens)
 
     def _structured_path_tokens(self, finding: FindingRecord) -> tuple[str | int, ...]:
@@ -402,19 +389,13 @@ class StructuredWorkflowService:
         if not isinstance(raw_tokens, list) or not all(
             isinstance(item, str) for item in raw_tokens
         ):
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="Structured finding is missing safe path metadata",
-            )
+            raise UnprocessableContentError("Structured finding is missing safe path metadata")
         return self._deserialize_path_tokens(raw_tokens)
 
     def _structured_path(self, finding: FindingRecord) -> str:
         path = finding.metadata.get("structured_path")
         if not isinstance(path, str) or not path:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="Structured finding is missing safe path metadata",
-            )
+            raise UnprocessableContentError("Structured finding is missing safe path metadata")
         return path
 
     def _resolve_leaf_value(
@@ -428,14 +409,12 @@ class StructuredWorkflowService:
             try:
                 current = current[token]
             except (KeyError, IndexError, TypeError) as exc:
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail=f"Structured payload no longer matches stored finding path `{path}`",
+                raise UnprocessableContentError(
+                    f"Structured payload no longer matches stored finding path `{path}`",
                 ) from exc
         if not isinstance(current, str):
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=f"Structured payload path `{path}` must resolve to a string value",
+            raise UnprocessableContentError(
+                f"Structured payload path `{path}` must resolve to a string value",
             )
         return current
 
@@ -447,26 +426,21 @@ class StructuredWorkflowService:
         path: str,
     ) -> None:
         if not path_tokens:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=f"Structured payload path `{path}` is invalid",
-            )
+            raise UnprocessableContentError(f"Structured payload path `{path}` is invalid")
         parent: Any = data
         for token in path_tokens[:-1]:
             try:
                 parent = parent[token]
             except (KeyError, IndexError, TypeError) as exc:
-                raise HTTPException(
-                    status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail=f"Structured payload no longer matches stored finding path `{path}`",
+                raise UnprocessableContentError(
+                    f"Structured payload no longer matches stored finding path `{path}`",
                 ) from exc
         leaf_token = path_tokens[-1]
         try:
             parent[leaf_token] = value
         except (KeyError, IndexError, TypeError) as exc:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=f"Structured payload no longer matches stored finding path `{path}`",
+            raise UnprocessableContentError(
+                f"Structured payload no longer matches stored finding path `{path}`",
             ) from exc
 
     def _apply_override(
@@ -478,10 +452,7 @@ class StructuredWorkflowService:
             return
         finding = stored_findings.get(override.finding_id)
         if finding is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND,
-                detail=f"Finding {override.finding_id} not found",
-            )
+            raise NotFoundError(f"Finding {override.finding_id} not found")
         if override.decision is not None:
             finding.decision = override.decision
         if override.transformation is not None:

--- a/src/obsura_api/services/studio.py
+++ b/src/obsura_api/services/studio.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from obsura_api.db.models import CustomEntity, Pattern, StudioConfiguration
 from obsura_api.domain.common import PaginationMeta, PaginationParams, build_pagination_meta
 from obsura_api.domain.enums import MatcherKind
+from obsura_api.domain.errors import NotFoundError
 from obsura_api.domain.studio import (
     ConfigurationCreate,
     ConfigurationRead,
@@ -56,13 +56,13 @@ class StudioService:
     def get_pattern(self, pattern_id: str) -> PatternRead:
         pattern = self.session.get(Pattern, pattern_id)
         if pattern is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Pattern not found")
+            raise NotFoundError("Pattern not found")
         return PatternRead.model_validate(pattern, from_attributes=True)
 
     def update_pattern(self, pattern_id: str, payload: PatternUpdate) -> PatternRead:
         pattern = self.session.get(Pattern, pattern_id)
         if pattern is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Pattern not found")
+            raise NotFoundError("Pattern not found")
         for field_name, value in payload.model_dump(exclude_unset=True).items():
             setattr(pattern, field_name, value)
         self.session.commit()
@@ -110,7 +110,7 @@ class StudioService:
     def get_custom_entity(self, entity_id: str) -> CustomEntityRead:
         entity = self.session.get(CustomEntity, entity_id)
         if entity is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Custom entity not found")
+            raise NotFoundError("Custom entity not found")
         return CustomEntityRead.model_validate(entity, from_attributes=True)
 
     def update_custom_entity(
@@ -120,7 +120,7 @@ class StudioService:
     ) -> CustomEntityRead:
         entity = self.session.get(CustomEntity, entity_id)
         if entity is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Custom entity not found")
+            raise NotFoundError("Custom entity not found")
         for field_name, value in payload.model_dump(exclude_unset=True).items():
             setattr(entity, field_name, value)
         self.session.commit()
@@ -170,7 +170,7 @@ class StudioService:
     def get_configuration(self, configuration_id: str) -> ConfigurationRead:
         configuration = self.session.get(StudioConfiguration, configuration_id)
         if configuration is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Configuration not found")
+            raise NotFoundError("Configuration not found")
         return self._configuration_to_schema(configuration)
 
     def update_configuration(
@@ -180,7 +180,7 @@ class StudioService:
     ) -> ConfigurationRead:
         configuration = self.session.get(StudioConfiguration, configuration_id)
         if configuration is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Configuration not found")
+            raise NotFoundError("Configuration not found")
         updates = payload.model_dump(exclude_unset=True)
         self._validate_configuration_references(
             pattern_ids=updates.get("pattern_ids", configuration.pattern_ids),
@@ -267,8 +267,5 @@ class StudioService:
         missing_ids = [item_id for item_id in expected_ids if item_id not in by_id]
         if missing_ids:
             missing_label = ", ".join(missing_ids)
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND,
-                detail=f"{entity_label} reference not found: {missing_label}",
-            )
+            raise NotFoundError(f"{entity_label} reference not found: {missing_label}")
         return [by_id[item_id] for item_id in expected_ids]

--- a/src/obsura_api/services/text_transformations.py
+++ b/src/obsura_api/services/text_transformations.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 
-from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
@@ -17,6 +16,7 @@ from obsura_api.domain.enums import (
     ReviewDecision,
     TransformationMode,
 )
+from obsura_api.domain.errors import BadRequestError, NotFoundError, UnprocessableContentError
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import (
     FindingOverride,
@@ -56,10 +56,7 @@ class TextTransformationService:
 
     def transform_job(self, request: TextTransformRequest) -> TextTransformResponse:
         if not request.job_id:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="`job_id` is required for direct transform requests",
-            )
+            raise UnprocessableContentError("`job_id` is required for direct transform requests")
 
         job = self._load_text_job(str(request.job_id))
         return self.transform_loaded_job(job, request)
@@ -99,10 +96,7 @@ class TextTransformationService:
         """Transform a loaded text job."""
 
         if job.content_type not in {ContentType.TEXT, ContentType.STRUCTURED_TEXT}:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Only text jobs can be transformed with this endpoint",
-            )
+            raise BadRequestError("Only text jobs can be transformed with this endpoint")
 
         stored_findings = {item.id: item for item in job.findings}
         for override in request.finding_overrides:
@@ -110,9 +104,8 @@ class TextTransformationService:
 
         content = request.content or job.source_text
         if not content:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                detail="Job does not retain source text; resubmit content to transform it",
+            raise BadRequestError(
+                "Job does not retain source text; resubmit content to transform it",
             )
 
         findings = [finding_to_schema(item) for item in job.findings]
@@ -209,10 +202,7 @@ class TextTransformationService:
             return
         finding = stored_findings.get(override.finding_id)
         if finding is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND,
-                detail=f"Finding {override.finding_id} not found",
-            )
+            raise NotFoundError(f"Finding {override.finding_id} not found")
         if override.decision is not None:
             finding.decision = override.decision
         if override.transformation is not None:
@@ -308,9 +298,8 @@ class TextTransformationService:
 
     def _require_hash_salt(self) -> str:
         if self.settings is None or not self.settings.text_hash_salt:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=(
+            raise UnprocessableContentError(
+                (
                     "Hash transformations require OBSURA_TEXT_HASH_SALT to be configured "
                     "on this deployment"
                 ),
@@ -324,5 +313,5 @@ class TextTransformationService:
             .options(selectinload(Job.findings), selectinload(Job.outputs)),
         )
         if job is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Job not found")
+            raise NotFoundError("Job not found")
         return job

--- a/tests/test_service_errors.py
+++ b/tests/test_service_errors.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+
+from obsura_api.domain.common import PaginationParams
+from obsura_api.domain.errors import UnprocessableContentError
+from obsura_api.services.search import SearchService
+
+
+class DummySession:
+    pass
+
+
+def test_unprocessable_content_error_uses_http_status_name_by_default() -> None:
+    error = UnprocessableContentError("Invalid content")
+
+    assert error.status_code == 422
+    assert error.code == HTTPStatus(422).name.lower()
+    assert error.message == "Invalid content"
+
+
+def test_search_service_raises_native_error_for_blank_query() -> None:
+    service = SearchService(DummySession())
+
+    with pytest.raises(UnprocessableContentError, match="Search query must not be blank"):
+        service.search("", PaginationParams(page=1, page_size=10))


### PR DESCRIPTION
## Summary

This PR introduces a native application error boundary for `obsura-api`.

The main goal is to keep transport concerns in the API layer and keep service/provider code framework-agnostic, easier to test, and easier to maintain as a public open-source project.

## What changed

- added a native application error hierarchy in `src/obsura_api/domain/errors.py`
- added unified API handling for native app errors in `src/obsura_api/api/responses.py`
- registered the app error handler in `src/obsura_api/app.py`
- migrated service and provider modules away from raising FastAPI `HTTPException`
- updated bulk/image error catch paths to handle native app errors consistently
- added focused tests for the new error boundary

## Why this matters

This improves internal architecture in a few important ways:

- service code no longer depends on FastAPI transport exceptions
- provider code can fail with domain-native errors instead of web-framework types
- error behavior is still returned to clients through the same unified API envelope
- future refactors are easier because service logic is no longer coupled to HTTP transport details

## Scope

The following layers were migrated:

- search
- studio
- jobs
- text transformations
- detection
- bulk workflows
- structured workflows
- document workflows
- CSV workflows
- image workflows
- document extractor provider

Route-level request parsing and transport validation still use FastAPI `HTTPException` where appropriate. That behavior is intentional.

## Validation

Executed successfully:

```bash
python -m ruff format --check src tests
python -m ruff check src tests
python -m mypy
python -m pytest --cov=src/obsura_api --cov-report=term-missing:skip-covered
```

Result:
- `109 passed`
- coverage: `80.33%`