### PR TITLE
feat: add explicit preview/share artifact metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,23 @@ Quality commands:
 - `python -m mypy`
 - `python -m pytest --cov=src/obsura_api`
 
-The default database is SQLite for local execution and tests. Production should
-use PostgreSQL as defined in
-[docs/architecture/STACK.md](docs/architecture/STACK.md).
+## Database Modes
+
+`obsura-api` supports both SQLite and PostgreSQL, but they are not equivalent
+deployment choices.
+
+- local development and tests default to SQLite when `DATABASE_URL` is not set
+- production must use PostgreSQL
+- if `OBSURA_ENVIRONMENT=production`, the app rejects SQLite and requires a
+  PostgreSQL `DATABASE_URL`
+
+Examples:
+
+- local default fallback: `sqlite:///./data/obsura.db`
+- production example: `postgresql://obsura:change-me@postgres:5432/obsura`
+
+To confirm what a running instance is using, call `GET /api/v1/version` and
+check `data.database_backend`.
 
 Alembic migrations are now the authoritative schema mechanism for the project.
 The API no longer treats SQLAlchemy `create_all()` as the production schema

--- a/docs/architecture/STACK.md
+++ b/docs/architecture/STACK.md
@@ -45,6 +45,9 @@ Python also keeps the stack aligned with the open-source tooling most relevant t
 
 The approved database direction is **PostgreSQL**.
 
+SQLite is still allowed as a local-only development and test convenience, but
+it is not the approved production database.
+
 `obsura-api` is not a stateless utility. It must support a persistent studio model that stores:
 - patterns
 - custom entities

--- a/guide/FRONTEND_API_GUIDE.md
+++ b/guide/FRONTEND_API_GUIDE.md
@@ -119,12 +119,15 @@ Response behavior:
 
 - transform responses may include `output_intent`
 - transform responses may include `share_policy`
+- transform responses now include `artifacts`
 - persisted job outputs may also include these values in output `metadata`
+- persisted job outputs may include a normalized `artifact` object
 
 Frontend rules:
 
 - default to `preview` unless the user is intentionally generating a shareable result
 - show `share_policy.notes` in operator-facing export UI when present
+- use `artifacts` as the authoritative description of what the backend produced
 - do not assume every transformation mode is valid under `safe_share`
 - treat `safe_share` as a backend-enforced policy, not only a visual styling choice
 
@@ -173,6 +176,8 @@ Stable frontend meaning:
 - findings belong to jobs
 - outputs belong to jobs
 - review updates happen at the job level
+- each stored output may expose an `artifact` object describing whether it is a
+  preview-style or share-style output and how the client should present it
 
 ### Text Workflows
 
@@ -190,6 +195,7 @@ Frontend guidance:
   retained by the backend
 - use `output_intent: "safe_share"` when the operator is generating externally
   shareable text output
+- use `artifacts[0]` as the primary transformed text artifact descriptor
 - use `pii_detection` when the operator needs language, entity scope, or context
   tuning for Presidio-backed detection
 
@@ -211,6 +217,7 @@ Frontend guidance:
 - for reviewed CSV jobs, resend the original CSV file to `transform-job`; raw CSV
   source files are not retained by the backend
 - use `output_intent: "safe_share"` for final share/export flows
+- use `artifacts` to distinguish the review table from the exportable CSV
 - use `output_csv` for file downloads; it is formula-safe and escapes spreadsheet
   formula-like cells before export
 - use `output_rows` for preview UI if you do not want the formula-safe export
@@ -234,6 +241,7 @@ Frontend guidance:
 - for reviewed document jobs, resend the original PDF file to `transform-job`;
   raw PDF source files are not retained by the backend
 - use `output_intent: "safe_share"` for final reviewed share flows
+- use `artifacts[0]` as the primary transformed document artifact descriptor
 - scanned or image-only PDFs are intentionally rejected for now; OCR-backed PDF
   support is deferred
 
@@ -255,6 +263,7 @@ Frontend guidance:
   source content is not retained by the backend
 - use `output_intent: "safe_share"` when the transformed JSON is intended for
   external sharing
+- use `artifacts[0]` as the primary transformed JSON artifact descriptor
 - structured workflows use the same review endpoint family under `/api/v1/jobs/{job_id}/review`
 
 ### Image Workflows
@@ -276,6 +285,8 @@ Frontend guidance:
   as text workflows
 - use `output_intent: "preview"` for blur/pixelate-driven review visuals
 - use `output_intent: "safe_share"` for final shared screenshots/images
+- use `artifacts[0]` for the canonical generated image artifact and `media_url`
+  from that artifact when present
 - under `safe_share`, OCR or text-derived findings cannot use blur or pixelation;
   the backend will reject explicit blur/pixelate requests and may auto-upgrade
   implicit preview defaults to a destructive overlay

--- a/guide/FRONTEND_API_GUIDE.md
+++ b/guide/FRONTEND_API_GUIDE.md
@@ -29,6 +29,7 @@ Frontend expectation:
   `pii_custom_recognizers` are configured
 - use `/api/v1/version` to discover `text_anonymizer_backend` and whether
   `text_hash_supported` is enabled on the deployment
+- use `/api/v1/version` to discover supported `share_output_intents`
 - do not use `/api/v1/health` as a full readiness signal
 - local development CORS allows `http://127.0.0.1:3000` and
   `http://localhost:3000` by default
@@ -100,6 +101,33 @@ Frontend rules:
 
 ## 4. Stable Resource Areas
 
+### Share Intent Contract
+
+Transform workflows now support an explicit `output_intent`.
+
+Supported values:
+
+- `preview`
+- `safe_share`
+
+Meaning:
+
+- `preview` is for operator review, internal iteration, and presentation-oriented output
+- `safe_share` is for export behavior that should enforce stricter sharing rules
+
+Response behavior:
+
+- transform responses may include `output_intent`
+- transform responses may include `share_policy`
+- persisted job outputs may also include these values in output `metadata`
+
+Frontend rules:
+
+- default to `preview` unless the user is intentionally generating a shareable result
+- show `share_policy.notes` in operator-facing export UI when present
+- do not assume every transformation mode is valid under `safe_share`
+- treat `safe_share` as a backend-enforced policy, not only a visual styling choice
+
 ### Studio
 
 Purpose:
@@ -160,6 +188,8 @@ Frontend guidance:
 - treat `analyze-transform` as a convenience path, not the main review-first UI
 - when transforming a persisted text job, resend `content`; raw source text is not
   retained by the backend
+- use `output_intent: "safe_share"` when the operator is generating externally
+  shareable text output
 - use `pii_detection` when the operator needs language, entity scope, or context
   tuning for Presidio-backed detection
 
@@ -180,6 +210,7 @@ Frontend guidance:
   `csv_row_number`, `csv_column_index`, and `csv_column_name`
 - for reviewed CSV jobs, resend the original CSV file to `transform-job`; raw CSV
   source files are not retained by the backend
+- use `output_intent: "safe_share"` for final share/export flows
 - use `output_csv` for file downloads; it is formula-safe and escapes spreadsheet
   formula-like cells before export
 - use `output_rows` for preview UI if you do not want the formula-safe export
@@ -202,6 +233,7 @@ Frontend guidance:
   `document_page_number` and `document_page_label`
 - for reviewed document jobs, resend the original PDF file to `transform-job`;
   raw PDF source files are not retained by the backend
+- use `output_intent: "safe_share"` for final reviewed share flows
 - scanned or image-only PDFs are intentionally rejected for now; OCR-backed PDF
   support is deferred
 
@@ -221,6 +253,8 @@ Frontend guidance:
 - use `finding.metadata.structured_path` to show the field location in review UI
 - for persisted structured jobs, resend `data` to `transform-job`; raw structured
   source content is not retained by the backend
+- use `output_intent: "safe_share"` when the transformed JSON is intended for
+  external sharing
 - structured workflows use the same review endpoint family under `/api/v1/jobs/{job_id}/review`
 
 ### Image Workflows
@@ -240,6 +274,11 @@ Frontend guidance:
   provided
 - OCR-driven text detection inside images accepts the same `pii_detection` object
   as text workflows
+- use `output_intent: "preview"` for blur/pixelate-driven review visuals
+- use `output_intent: "safe_share"` for final shared screenshots/images
+- under `safe_share`, OCR or text-derived findings cannot use blur or pixelation;
+  the backend will reject explicit blur/pixelate requests and may auto-upgrade
+  implicit preview defaults to a destructive overlay
 
 ### Bulk Text Workflows
 

--- a/openapi.json
+++ b/openapi.json
@@ -4248,6 +4248,26 @@
             "type": "array",
             "title": "Replacements"
           },
+          "output_intent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputIntent"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "share_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SharePolicySummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "summary": {
             "additionalProperties": {
               "type": "integer"
@@ -4376,25 +4396,7 @@
             "title": "Face Preferences"
           },
           "metadata": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "boolean"
-                },
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              ]
-            },
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           }
@@ -4526,25 +4528,7 @@
             "title": "Face Preferences"
           },
           "metadata": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "boolean"
-                },
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              ]
-            },
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
@@ -4722,25 +4706,7 @@
           "metadata": {
             "anyOf": [
               {
-                "additionalProperties": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    }
-                  ]
-                },
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -5189,6 +5155,26 @@
             "type": "array",
             "title": "Replacements"
           },
+          "output_intent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputIntent"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "share_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SharePolicySummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "summary": {
             "additionalProperties": {
               "type": "integer"
@@ -5401,25 +5387,7 @@
             ]
           },
           "metadata": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "boolean"
-                },
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              ]
-            },
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           }
@@ -5512,6 +5480,10 @@
             "title": "Include Pending",
             "default": false
           },
+          "output_intent": {
+            "$ref": "#/components/schemas/OutputIntent",
+            "default": "preview"
+          },
           "persist_output": {
             "type": "boolean",
             "title": "Persist Output",
@@ -5581,6 +5553,26 @@
             ],
             "title": "Media Url",
             "description": "Media URL derived from the storage-relative output reference."
+          },
+          "output_intent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputIntent"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "share_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SharePolicySummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "summary": {
             "additionalProperties": {
@@ -5657,25 +5649,7 @@
             "description": "Media URL derived from the storage-relative output reference."
           },
           "metadata": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "boolean"
-                },
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              ]
-            },
+            "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           }
@@ -5937,6 +5911,14 @@
           "value_list"
         ],
         "title": "MatcherKind"
+      },
+      "OutputIntent": {
+        "type": "string",
+        "enum": [
+          "preview",
+          "safe_share"
+        ],
+        "title": "OutputIntent"
       },
       "OverlayShape": {
         "type": "string",
@@ -6591,6 +6573,13 @@
             "type": "boolean",
             "title": "Text Hash Supported"
           },
+          "share_output_intents": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Share Output Intents"
+          },
           "ocr_available": {
             "type": "boolean",
             "title": "Ocr Available"
@@ -6623,12 +6612,41 @@
           "pii_languages",
           "pii_custom_recognizers",
           "text_hash_supported",
+          "share_output_intents",
           "ocr_available",
           "face_detection_available",
           "pii_available"
         ],
         "title": "ServiceVersionInfo",
         "description": "Runtime version and capability metadata."
+      },
+      "SharePolicySummary": {
+        "properties": {
+          "output_intent": {
+            "$ref": "#/components/schemas/OutputIntent",
+            "default": "preview"
+          },
+          "security_rules_enforced": {
+            "type": "boolean",
+            "title": "Security Rules Enforced",
+            "default": false
+          },
+          "auto_adjusted": {
+            "type": "boolean",
+            "title": "Auto Adjusted",
+            "default": false
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "title": "SharePolicySummary",
+        "description": "How the API interpreted a transform request for sharing."
       },
       "StructuredAnalysisRequest": {
         "properties": {
@@ -6712,6 +6730,10 @@
               }
             ]
           },
+          "output_intent": {
+            "$ref": "#/components/schemas/OutputIntent",
+            "default": "preview"
+          },
           "persist_job": {
             "type": "boolean",
             "title": "Persist Job",
@@ -6778,6 +6800,10 @@
                 "type": "null"
               }
             ]
+          },
+          "output_intent": {
+            "$ref": "#/components/schemas/OutputIntent",
+            "default": "preview"
           },
           "persist_output": {
             "type": "boolean",
@@ -6933,6 +6959,10 @@
               }
             ]
           },
+          "output_intent": {
+            "$ref": "#/components/schemas/OutputIntent",
+            "default": "preview"
+          },
           "persist_job": {
             "type": "boolean",
             "title": "Persist Job",
@@ -7005,6 +7035,26 @@
             },
             "type": "array",
             "title": "Replacements"
+          },
+          "output_intent": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputIntent"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "share_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SharePolicySummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "summary": {
             "additionalProperties": {
@@ -7106,6 +7156,10 @@
                 "type": "null"
               }
             ]
+          },
+          "output_intent": {
+            "$ref": "#/components/schemas/OutputIntent",
+            "default": "preview"
           },
           "persist_job": {
             "type": "boolean",
@@ -7215,6 +7269,10 @@
               }
             ]
           },
+          "output_intent": {
+            "$ref": "#/components/schemas/OutputIntent",
+            "default": "preview"
+          },
           "persist_output": {
             "type": "boolean",
             "title": "Persist Output",
@@ -7249,6 +7307,20 @@
             },
             "type": "array",
             "title": "Replacements"
+          },
+          "output_intent": {
+            "$ref": "#/components/schemas/OutputIntent",
+            "default": "preview"
+          },
+          "share_policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SharePolicySummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "summary": {
             "additionalProperties": {

--- a/openapi.json
+++ b/openapi.json
@@ -4268,6 +4268,13 @@
               }
             ]
           },
+          "artifacts": {
+            "items": {
+              "$ref": "#/components/schemas/ShareArtifactSummary"
+            },
+            "type": "array",
+            "title": "Artifacts"
+          },
           "summary": {
             "additionalProperties": {
               "type": "integer"
@@ -5175,6 +5182,13 @@
               }
             ]
           },
+          "artifacts": {
+            "items": {
+              "$ref": "#/components/schemas/ShareArtifactSummary"
+            },
+            "type": "array",
+            "title": "Artifacts"
+          },
           "summary": {
             "additionalProperties": {
               "type": "integer"
@@ -5574,6 +5588,13 @@
               }
             ]
           },
+          "artifacts": {
+            "items": {
+              "$ref": "#/components/schemas/ShareArtifactSummary"
+            },
+            "type": "array",
+            "title": "Artifacts"
+          },
           "summary": {
             "additionalProperties": {
               "type": "integer"
@@ -5647,6 +5668,16 @@
             ],
             "title": "Media Url",
             "description": "Media URL derived from the storage-relative output reference."
+          },
+          "artifact": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ShareArtifactSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "metadata": {
             "additionalProperties": true,
@@ -6620,6 +6651,102 @@
         "title": "ServiceVersionInfo",
         "description": "Runtime version and capability metadata."
       },
+      "ShareArtifactChannel": {
+        "type": "string",
+        "enum": [
+          "inline",
+          "download",
+          "media"
+        ],
+        "title": "ShareArtifactChannel"
+      },
+      "ShareArtifactKind": {
+        "type": "string",
+        "enum": [
+          "text",
+          "json",
+          "table_preview",
+          "csv_export",
+          "image"
+        ],
+        "title": "ShareArtifactKind"
+      },
+      "ShareArtifactSummary": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ShareArtifactKind"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ShareArtifactChannel"
+          },
+          "intended_use": {
+            "$ref": "#/components/schemas/OutputIntent"
+          },
+          "share_ready": {
+            "type": "boolean",
+            "title": "Share Ready",
+            "default": false
+          },
+          "primary": {
+            "type": "boolean",
+            "title": "Primary",
+            "default": false
+          },
+          "filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filename"
+          },
+          "output_file_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output File Path"
+          },
+          "media_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Media Url"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "kind",
+          "channel",
+          "intended_use"
+        ],
+        "title": "ShareArtifactSummary",
+        "description": "One explicit artifact produced for preview or sharing."
+      },
       "SharePolicySummary": {
         "properties": {
           "output_intent": {
@@ -7056,6 +7183,13 @@
               }
             ]
           },
+          "artifacts": {
+            "items": {
+              "$ref": "#/components/schemas/ShareArtifactSummary"
+            },
+            "type": "array",
+            "title": "Artifacts"
+          },
           "summary": {
             "additionalProperties": {
               "type": "integer"
@@ -7321,6 +7455,13 @@
                 "type": "null"
               }
             ]
+          },
+          "artifacts": {
+            "items": {
+              "$ref": "#/components/schemas/ShareArtifactSummary"
+            },
+            "type": "array",
+            "title": "Artifacts"
           },
           "summary": {
             "additionalProperties": {

--- a/postman.json
+++ b/postman.json
@@ -2505,7 +2505,7 @@
                 {
                   "key": "manifest_json",
                   "type": "text",
-                  "value": "{\n  \"title\": \"Customer export transform\",\n  \"pattern_ids\": [\n    \"{{patternId}}\"\n  ],\n  \"custom_entity_ids\": [\n    \"{{entityId}}\"\n  ],\n  \"configuration_ids\": [\n    \"{{configurationId}}\"\n  ],\n  \"pii_detection\": {\n    \"language\": \"en\",\n    \"entity_allow_list\": [\n      \"EMAIL_ADDRESS\",\n      \"PERSON\"\n    ],\n    \"context_words\": [\n      \"customer\",\n      \"email\",\n      \"contact\"\n    ]\n  },\n  \"apply_builtins\": true,\n  \"exact_values\": [\n    \"secret\"\n  ],\n  \"has_header\": true,\n  \"persist_job\": true\n}"
+                  "value": "{\n  \"title\": \"Customer export transform\",\n  \"pattern_ids\": [\n    \"{{patternId}}\"\n  ],\n  \"custom_entity_ids\": [\n    \"{{entityId}}\"\n  ],\n  \"configuration_ids\": [\n    \"{{configurationId}}\"\n  ],\n  \"pii_detection\": {\n    \"language\": \"en\",\n    \"entity_allow_list\": [\n      \"EMAIL_ADDRESS\",\n      \"PERSON\"\n    ],\n    \"context_words\": [\n      \"customer\",\n      \"email\",\n      \"contact\"\n    ]\n  },\n  \"apply_builtins\": true,\n  \"exact_values\": [\n    \"secret\"\n  ],\n  \"output_intent\": \"safe_share\",\n  \"has_header\": true,\n  \"persist_job\": true\n}"
                 }
               ]
             }
@@ -2615,7 +2615,7 @@
                 {
                   "key": "manifest_json",
                   "type": "text",
-                  "value": "{\n  \"job_id\": \"{{jobId}}\",\n  \"finding_overrides\": [\n    {\n      \"finding_id\": \"{{findingId}}\",\n      \"decision\": \"approved\"\n    }\n  ],\n  \"include_pending\": false,\n  \"persist_output\": true\n}"
+                  "value": "{\n  \"job_id\": \"{{jobId}}\",\n  \"finding_overrides\": [\n    {\n      \"finding_id\": \"{{findingId}}\",\n      \"decision\": \"approved\"\n    }\n  ],\n  \"include_pending\": false,\n  \"output_intent\": \"safe_share\",\n  \"persist_output\": true\n}"
                 }
               ]
             }
@@ -2841,7 +2841,7 @@
                 {
                   "key": "manifest_json",
                   "type": "text",
-                  "value": "{\n  \"title\": \"Customer contract export\",\n  \"pattern_ids\": [\n    \"{{patternId}}\"\n  ],\n  \"custom_entity_ids\": [\n    \"{{entityId}}\"\n  ],\n  \"configuration_ids\": [\n    \"{{configurationId}}\"\n  ],\n  \"pii_detection\": {\n    \"language\": \"en\",\n    \"entity_allow_list\": [\n      \"EMAIL_ADDRESS\",\n      \"PERSON\"\n    ],\n    \"context_words\": [\n      \"customer\",\n      \"contract\",\n      \"contact\"\n    ]\n  },\n  \"exact_values\": [\n    \"secret\"\n  ],\n  \"apply_builtins\": true,\n  \"persist_job\": true\n}"
+                  "value": "{\n  \"title\": \"Customer contract export\",\n  \"pattern_ids\": [\n    \"{{patternId}}\"\n  ],\n  \"custom_entity_ids\": [\n    \"{{entityId}}\"\n  ],\n  \"configuration_ids\": [\n    \"{{configurationId}}\"\n  ],\n  \"pii_detection\": {\n    \"language\": \"en\",\n    \"entity_allow_list\": [\n      \"EMAIL_ADDRESS\",\n      \"PERSON\"\n    ],\n    \"context_words\": [\n      \"customer\",\n      \"contract\",\n      \"contact\"\n    ]\n  },\n  \"exact_values\": [\n    \"secret\"\n  ],\n  \"apply_builtins\": true,\n  \"output_intent\": \"safe_share\",\n  \"persist_job\": true\n}"
                 }
               ]
             }
@@ -2951,7 +2951,7 @@
                 {
                   "key": "manifest_json",
                   "type": "text",
-                  "value": "{\n  \"job_id\": \"{{jobId}}\",\n  \"finding_overrides\": [\n    {\n      \"finding_id\": \"{{findingId}}\",\n      \"decision\": \"approved\"\n    }\n  ],\n  \"include_pending\": false,\n  \"persist_output\": true\n}"
+                  "value": "{\n  \"job_id\": \"{{jobId}}\",\n  \"finding_overrides\": [\n    {\n      \"finding_id\": \"{{findingId}}\",\n      \"decision\": \"approved\"\n    }\n  ],\n  \"include_pending\": false,\n  \"output_intent\": \"safe_share\",\n  \"persist_output\": true\n}"
                 }
               ]
             }
@@ -3170,7 +3170,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"job_id\": \"{{jobId}}\",\n  \"content\": \"Connect to https://internal.example.com from 10.0.0.1 as root\",\n  \"finding_overrides\": [\n    {\n      \"finding_id\": \"{{findingId}}\",\n      \"decision\": \"approved\",\n      \"transformation\": {\n        \"mode\": \"semantic\",\n        \"semantic_label\": \"INTERNAL_DOMAIN\"\n      }\n    }\n  ],\n  \"include_pending\": false,\n  \"persist_output\": true\n}",
+              "raw": "{\n  \"job_id\": \"{{jobId}}\",\n  \"content\": \"Connect to https://internal.example.com from 10.0.0.1 as root\",\n  \"finding_overrides\": [\n    {\n      \"finding_id\": \"{{findingId}}\",\n      \"decision\": \"approved\",\n      \"transformation\": {\n        \"mode\": \"semantic\",\n        \"semantic_label\": \"INTERNAL_DOMAIN\"\n      }\n    }\n  ],\n  \"include_pending\": false,\n  \"output_intent\": \"safe_share\",\n  \"persist_output\": true\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -3500,7 +3500,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"title\": \"Structured one-shot export\",\n  \"data\": {\n    \"customer\": {\n      \"email\": \"john@example.com\",\n      \"token\": \"secret\"\n    }\n  },\n  \"exact_values\": [\n    \"secret\"\n  ],\n  \"persist_job\": false\n}",
+              "raw": "{\n  \"title\": \"Structured one-shot export\",\n  \"data\": {\n    \"customer\": {\n      \"email\": \"john@example.com\",\n      \"token\": \"secret\"\n    }\n  },\n  \"exact_values\": [\n    \"secret\"\n  ],\n  \"output_intent\": \"safe_share\",\n  \"persist_job\": false\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -3608,7 +3608,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"job_id\": \"{{jobId}}\",\n  \"data\": {\n    \"customer\": {\n      \"email\": \"john@example.com\",\n      \"id\": \"CUST-123\"\n    }\n  },\n  \"finding_overrides\": [\n    {\n      \"finding_id\": \"{{findingId}}\",\n      \"decision\": \"approved\"\n    }\n  ],\n  \"include_pending\": false,\n  \"persist_output\": true\n}",
+              "raw": "{\n  \"job_id\": \"{{jobId}}\",\n  \"data\": {\n    \"customer\": {\n      \"email\": \"john@example.com\",\n      \"id\": \"CUST-123\"\n    }\n  },\n  \"finding_overrides\": [\n    {\n      \"finding_id\": \"{{findingId}}\",\n      \"decision\": \"approved\"\n    }\n  ],\n  \"include_pending\": false,\n  \"output_intent\": \"safe_share\",\n  \"persist_output\": true\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -3727,7 +3727,7 @@
                 {
                   "key": "manifest_json",
                   "type": "text",
-                  "value": "{\n  \"title\": \"Screenshot region review\",\n  \"content_type\": \"screenshot\",\n  \"configuration_ids\": [\n    \"{{configurationId}}\"\n  ],\n  \"pattern_ids\": [\n    \"{{patternId}}\"\n  ],\n  \"custom_entity_ids\": [\n    \"{{entityId}}\"\n  ],\n  \"pii_detection\": {\n    \"language\": \"en\",\n    \"entity_allow_list\": [\n      \"PERSON\",\n      \"EMAIL_ADDRESS\"\n    ],\n    \"context_words\": [\n      \"customer\",\n      \"email\",\n      \"contact\"\n    ]\n  },\n  \"apply_builtins\": true,\n  \"detect_text\": true,\n  \"regions\": [\n    {\n      \"kind\": \"image_region\",\n      \"source\": \"manual\",\n      \"entity_type\": \"SECRET_REGION\",\n      \"entity_name\": \"Secret block\",\n      \"region\": {\n        \"x\": 48,\n        \"y\": 24,\n        \"width\": 240,\n        \"height\": 96\n      },\n      \"transformation\": {\n        \"mode\": \"blur\",\n        \"blur_radius\": 10\n      }\n    }\n  ],\n  \"detect_faces\": false,\n  \"persist_job\": true\n}"
+                  "value": "{\n  \"title\": \"Screenshot region review\",\n  \"content_type\": \"screenshot\",\n  \"configuration_ids\": [\n    \"{{configurationId}}\"\n  ],\n  \"pattern_ids\": [\n    \"{{patternId}}\"\n  ],\n  \"custom_entity_ids\": [\n    \"{{entityId}}\"\n  ],\n  \"pii_detection\": {\n    \"language\": \"en\",\n    \"entity_allow_list\": [\n      \"PERSON\",\n      \"EMAIL_ADDRESS\"\n    ],\n    \"context_words\": [\n      \"customer\",\n      \"email\",\n      \"contact\"\n    ]\n  },\n  \"apply_builtins\": true,\n  \"detect_text\": true,\n  \"output_intent\": \"safe_share\",\n  \"regions\": [\n    {\n      \"kind\": \"image_region\",\n      \"source\": \"manual\",\n      \"entity_type\": \"SECRET_REGION\",\n      \"entity_name\": \"Secret block\",\n      \"region\": {\n        \"x\": 48,\n        \"y\": 24,\n        \"width\": 240,\n        \"height\": 96\n      },\n      \"transformation\": {\n        \"mode\": \"blur\",\n        \"blur_radius\": 10\n      }\n    }\n  ],\n  \"detect_faces\": false,\n  \"persist_job\": true\n}"
                 }
               ]
             }
@@ -3942,7 +3942,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"job_id\": \"{{jobId}}\",\n  \"finding_overrides\": [\n    {\n      \"finding_id\": \"{{findingId}}\",\n      \"decision\": \"approved\",\n      \"transformation\": {\n        \"mode\": \"blur\",\n        \"blur_radius\": 12,\n        \"region_padding\": 6,\n        \"outline_color\": \"#ff4d4f\",\n        \"outline_width\": 2\n      }\n    }\n  ],\n  \"include_pending\": false,\n  \"persist_output\": true\n}",
+              "raw": "{\n  \"job_id\": \"{{jobId}}\",\n  \"finding_overrides\": [\n    {\n      \"finding_id\": \"{{findingId}}\",\n      \"decision\": \"approved\",\n      \"transformation\": {\n        \"mode\": \"blur\",\n        \"blur_radius\": 12,\n        \"region_padding\": 6,\n        \"outline_color\": \"#ff4d4f\",\n        \"outline_width\": 2\n      }\n    }\n  ],\n  \"include_pending\": false,\n  \"output_intent\": \"safe_share\",\n  \"persist_output\": true\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/src/obsura_api/api/routes/health.py
+++ b/src/obsura_api/api/routes/health.py
@@ -14,6 +14,7 @@ from obsura_api.core.settings import Settings
 from obsura_api.db.migrations import describe_schema_mismatch, get_schema_state
 from obsura_api.db.session import verify_database_connection
 from obsura_api.domain.common import ApiResponse
+from obsura_api.domain.enums import OutputIntent
 from obsura_api.domain.operational import ServiceVersionInfo
 
 router = APIRouter(tags=["health"])
@@ -81,6 +82,7 @@ def version(settings: SettingsDep, container: ContainerDep) -> ApiResponse[Servi
                 getattr(container.pii_detector, "custom_recognizers_configured", False),
             ),
             text_hash_supported=bool(getattr(container.text_anonymizer, "hash_supported", False)),
+            share_output_intents=[item.value for item in OutputIntent],
             ocr_available=container.ocr_provider.supported,
             face_detection_available=container.face_detector.supported,
             pii_available=container.pii_detector.supported,

--- a/src/obsura_api/api/routes/text_workflows.py
+++ b/src/obsura_api/api/routes/text_workflows.py
@@ -19,6 +19,7 @@ from obsura_api.domain.workflows import (
     TextTransformResponse,
 )
 from obsura_api.services.detection import TextDetectionService
+from obsura_api.services.sharing import build_text_share_policy
 from obsura_api.services.text_transformations import TextTransformationService
 
 router = APIRouter(prefix="/workflows/text", tags=["text-workflows"])
@@ -89,17 +90,22 @@ def analyze_and_transform_text(
         include_pending=True,
         default_transformation=payload.default_transformation,
     )
+    share_policy = build_text_share_policy(payload.output_intent)
     if analysis.job_id:
         transformer.persist_text_output(
             job_id=analysis.job_id,
             output_text=output_text,
             replacement_count=len(replacements),
+            output_intent=payload.output_intent,
+            share_policy=share_policy,
         )
     return success_response(
         TextTransformResponse(
             job_id=analysis.job_id,
             output_text=output_text,
             replacements=replacements,
+            output_intent=payload.output_intent,
+            share_policy=share_policy,
             summary={"replacement_count": len(replacements)},
         ),
     )

--- a/src/obsura_api/api/routes/text_workflows.py
+++ b/src/obsura_api/api/routes/text_workflows.py
@@ -19,7 +19,7 @@ from obsura_api.domain.workflows import (
     TextTransformResponse,
 )
 from obsura_api.services.detection import TextDetectionService
-from obsura_api.services.sharing import build_text_share_policy
+from obsura_api.services.sharing import build_text_artifact, build_text_share_policy
 from obsura_api.services.text_transformations import TextTransformationService
 
 router = APIRouter(prefix="/workflows/text", tags=["text-workflows"])
@@ -91,6 +91,10 @@ def analyze_and_transform_text(
         default_transformation=payload.default_transformation,
     )
     share_policy = build_text_share_policy(payload.output_intent)
+    artifact = build_text_artifact(
+        output_intent=payload.output_intent,
+        share_policy=share_policy,
+    )
     if analysis.job_id:
         transformer.persist_text_output(
             job_id=analysis.job_id,
@@ -106,6 +110,7 @@ def analyze_and_transform_text(
             replacements=replacements,
             output_intent=payload.output_intent,
             share_policy=share_policy,
+            artifacts=[artifact],
             summary={"replacement_count": len(replacements)},
         ),
     )

--- a/src/obsura_api/domain/common.py
+++ b/src/obsura_api/domain/common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from math import ceil
-from typing import Annotated, Any, Generic, TypeVar
+from typing import Annotated, Any, Generic, TypeAlias, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -19,6 +19,7 @@ UUID_REFERENCE_PATTERN = (
     r"[0-9a-fA-F]{12}$"
 )
 UuidReference = Annotated[str, Field(pattern=UUID_REFERENCE_PATTERN)]
+MetadataMap: TypeAlias = dict[str, Any]
 
 
 class TimestampedModel(BaseModel):

--- a/src/obsura_api/domain/csv_workflows.py
+++ b/src/obsura_api/domain/csv_workflows.py
@@ -7,8 +7,9 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from obsura_api.domain.common import UuidReference
-from obsura_api.domain.enums import ContentType
+from obsura_api.domain.enums import ContentType, OutputIntent
 from obsura_api.domain.pii import PIIDetectionOptions
+from obsura_api.domain.sharing import SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingOverride, FindingRecord
 
@@ -29,6 +30,7 @@ class CSVWorkflowManifest(BaseModel):
     pii_detection: PIIDetectionOptions | None = None
     exact_values: list[str] = Field(default_factory=list)
     default_transformation: TransformationRule | None = None
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_job: bool = True
     has_header: bool = True
     delimiter: CSVDelimiter = ","
@@ -69,6 +71,8 @@ class CSVWorkflowResponse(BaseModel):
     output_csv: str | None = None
     formula_escape_count: int = Field(default=0, ge=0)
     replacements: list[CSVReplacementRecord] = Field(default_factory=list)
+    output_intent: OutputIntent | None = None
+    share_policy: SharePolicySummary | None = None
     summary: dict[str, int]
 
 
@@ -81,4 +85,5 @@ class CSVJobTransformRequest(BaseModel):
     finding_overrides: list[FindingOverride] = Field(default_factory=list)
     include_pending: bool = False
     default_transformation: TransformationRule | None = None
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_output: bool = True

--- a/src/obsura_api/domain/csv_workflows.py
+++ b/src/obsura_api/domain/csv_workflows.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from obsura_api.domain.common import UuidReference
 from obsura_api.domain.enums import ContentType, OutputIntent
 from obsura_api.domain.pii import PIIDetectionOptions
-from obsura_api.domain.sharing import SharePolicySummary
+from obsura_api.domain.sharing import ShareArtifactSummary, SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingOverride, FindingRecord
 
@@ -73,6 +73,7 @@ class CSVWorkflowResponse(BaseModel):
     replacements: list[CSVReplacementRecord] = Field(default_factory=list)
     output_intent: OutputIntent | None = None
     share_policy: SharePolicySummary | None = None
+    artifacts: list[ShareArtifactSummary] = Field(default_factory=list)
     summary: dict[str, int]
 
 

--- a/src/obsura_api/domain/documents.py
+++ b/src/obsura_api/domain/documents.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from obsura_api.domain.common import UuidReference
 from obsura_api.domain.enums import ContentType, OutputIntent
 from obsura_api.domain.pii import PIIDetectionOptions
-from obsura_api.domain.sharing import SharePolicySummary
+from obsura_api.domain.sharing import ShareArtifactSummary, SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingOverride, FindingRecord
 
@@ -68,6 +68,7 @@ class DocumentWorkflowResponse(BaseModel):
     replacements: list[DocumentReplacementRecord] = Field(default_factory=list)
     output_intent: OutputIntent | None = None
     share_policy: SharePolicySummary | None = None
+    artifacts: list[ShareArtifactSummary] = Field(default_factory=list)
     summary: dict[str, int]
 
 

--- a/src/obsura_api/domain/documents.py
+++ b/src/obsura_api/domain/documents.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from obsura_api.domain.common import UuidReference
-from obsura_api.domain.enums import ContentType
+from obsura_api.domain.enums import ContentType, OutputIntent
 from obsura_api.domain.pii import PIIDetectionOptions
+from obsura_api.domain.sharing import SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingOverride, FindingRecord
 
@@ -25,6 +26,7 @@ class DocumentWorkflowManifest(BaseModel):
     pii_detection: PIIDetectionOptions | None = None
     exact_values: list[str] = Field(default_factory=list)
     default_transformation: TransformationRule | None = None
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_job: bool = True
 
     @model_validator(mode="after")
@@ -64,6 +66,8 @@ class DocumentWorkflowResponse(BaseModel):
     pages: list[DocumentPageResult] = Field(default_factory=list)
     output_text: str | None = None
     replacements: list[DocumentReplacementRecord] = Field(default_factory=list)
+    output_intent: OutputIntent | None = None
+    share_policy: SharePolicySummary | None = None
     summary: dict[str, int]
 
 
@@ -76,4 +80,5 @@ class DocumentJobTransformRequest(BaseModel):
     finding_overrides: list[FindingOverride] = Field(default_factory=list)
     include_pending: bool = False
     default_transformation: TransformationRule | None = None
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_output: bool = True

--- a/src/obsura_api/domain/enums.py
+++ b/src/obsura_api/domain/enums.py
@@ -46,6 +46,20 @@ class OutputIntent(str, Enum):
     SAFE_SHARE = "safe_share"
 
 
+class ShareArtifactKind(str, Enum):
+    TEXT = "text"
+    JSON = "json"
+    TABLE_PREVIEW = "table_preview"
+    CSV_EXPORT = "csv_export"
+    IMAGE = "image"
+
+
+class ShareArtifactChannel(str, Enum):
+    INLINE = "inline"
+    DOWNLOAD = "download"
+    MEDIA = "media"
+
+
 class OverlayShape(str, Enum):
     RECTANGLE = "rectangle"
     ROUNDED_RECTANGLE = "rounded_rectangle"

--- a/src/obsura_api/domain/enums.py
+++ b/src/obsura_api/domain/enums.py
@@ -41,6 +41,11 @@ class TransformationMode(str, Enum):
     IMAGE_REPLACEMENT = "image_replacement"
 
 
+class OutputIntent(str, Enum):
+    PREVIEW = "preview"
+    SAFE_SHARE = "safe_share"
+
+
 class OverlayShape(str, Enum):
     RECTANGLE = "rectangle"
     ROUNDED_RECTANGLE = "rounded_rectangle"

--- a/src/obsura_api/domain/jobs.py
+++ b/src/obsura_api/domain/jobs.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from obsura_api.domain.common import MetadataMap, TimestampedModel, UuidReference
 from obsura_api.domain.enums import ContentType, JobStatus, ReviewDecision
+from obsura_api.domain.sharing import ShareArtifactSummary
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingRecord
 
@@ -24,6 +25,7 @@ class JobOutputRecord(TimestampedModel):
         default=None,
         description="Media URL derived from the storage-relative output reference.",
     )
+    artifact: ShareArtifactSummary | None = None
     metadata: MetadataMap = Field(default_factory=dict)
 
 

--- a/src/obsura_api/domain/jobs.py
+++ b/src/obsura_api/domain/jobs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from obsura_api.domain.common import TimestampedModel, UuidReference
+from obsura_api.domain.common import MetadataMap, TimestampedModel, UuidReference
 from obsura_api.domain.enums import ContentType, JobStatus, ReviewDecision
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingRecord
@@ -24,7 +24,7 @@ class JobOutputRecord(TimestampedModel):
         default=None,
         description="Media URL derived from the storage-relative output reference.",
     )
-    metadata: dict[str, str | int | bool | list[str]] = Field(default_factory=dict)
+    metadata: MetadataMap = Field(default_factory=dict)
 
 
 class JobRead(TimestampedModel):

--- a/src/obsura_api/domain/operational.py
+++ b/src/obsura_api/domain/operational.py
@@ -38,6 +38,7 @@ class ServiceVersionInfo(BaseModel):
     pii_languages: list[str]
     pii_custom_recognizers: bool
     text_hash_supported: bool
+    share_output_intents: list[str]
     ocr_available: bool
     face_detection_available: bool
     pii_available: bool

--- a/src/obsura_api/domain/sharing.py
+++ b/src/obsura_api/domain/sharing.py
@@ -1,0 +1,16 @@
+"""Share policy request and response models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from obsura_api.domain.enums import OutputIntent
+
+
+class SharePolicySummary(BaseModel):
+    """How the API interpreted a transform request for sharing."""
+
+    output_intent: OutputIntent = OutputIntent.PREVIEW
+    security_rules_enforced: bool = False
+    auto_adjusted: bool = False
+    notes: list[str] = Field(default_factory=list)

--- a/src/obsura_api/domain/sharing.py
+++ b/src/obsura_api/domain/sharing.py
@@ -1,10 +1,10 @@
-"""Share policy request and response models."""
+"""Share policy and artifact request/response models."""
 
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
-from obsura_api.domain.enums import OutputIntent
+from obsura_api.domain.enums import OutputIntent, ShareArtifactChannel, ShareArtifactKind
 
 
 class SharePolicySummary(BaseModel):
@@ -13,4 +13,19 @@ class SharePolicySummary(BaseModel):
     output_intent: OutputIntent = OutputIntent.PREVIEW
     security_rules_enforced: bool = False
     auto_adjusted: bool = False
+    notes: list[str] = Field(default_factory=list)
+
+
+class ShareArtifactSummary(BaseModel):
+    """One explicit artifact produced for preview or sharing."""
+
+    name: str
+    kind: ShareArtifactKind
+    channel: ShareArtifactChannel
+    intended_use: OutputIntent
+    share_ready: bool = False
+    primary: bool = False
+    filename: str | None = None
+    output_file_path: str | None = None
+    media_url: str | None = None
     notes: list[str] = Field(default_factory=list)

--- a/src/obsura_api/domain/structured.py
+++ b/src/obsura_api/domain/structured.py
@@ -8,7 +8,9 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from obsura_api.domain.common import UuidReference
+from obsura_api.domain.enums import OutputIntent
 from obsura_api.domain.pii import PIIDetectionOptions
+from obsura_api.domain.sharing import SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingOverride, FindingRecord
 
@@ -49,6 +51,7 @@ class StructuredAnalysisRequest(BaseModel):
     pii_detection: PIIDetectionOptions | None = None
     exact_values: list[str] = Field(default_factory=list)
     default_transformation: TransformationRule | None = None
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_job: bool = True
     persist_source_content: bool | None = None
 
@@ -72,6 +75,7 @@ class StructuredTransformRequest(BaseModel):
     pii_detection: PIIDetectionOptions | None = None
     exact_values: list[str] = Field(default_factory=list)
     default_transformation: TransformationRule | None = None
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_job: bool = True
     persist_source_content: bool | None = None
     persist_output: bool = True
@@ -100,6 +104,8 @@ class StructuredWorkflowResponse(BaseModel):
     findings: list[FindingRecord]
     output_data: StructuredJSONValue | None = None
     replacements: list[StructuredReplacementRecord] = Field(default_factory=list)
+    output_intent: OutputIntent | None = None
+    share_policy: SharePolicySummary | None = None
     summary: dict[str, int]
 
 
@@ -113,6 +119,7 @@ class StructuredJobTransformRequest(BaseModel):
     finding_overrides: list[FindingOverride] = Field(default_factory=list)
     include_pending: bool = False
     default_transformation: TransformationRule | None = None
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_output: bool = True
 
     @model_validator(mode="after")

--- a/src/obsura_api/domain/structured.py
+++ b/src/obsura_api/domain/structured.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from obsura_api.domain.common import UuidReference
 from obsura_api.domain.enums import OutputIntent
 from obsura_api.domain.pii import PIIDetectionOptions
-from obsura_api.domain.sharing import SharePolicySummary
+from obsura_api.domain.sharing import ShareArtifactSummary, SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingOverride, FindingRecord
 
@@ -106,6 +106,7 @@ class StructuredWorkflowResponse(BaseModel):
     replacements: list[StructuredReplacementRecord] = Field(default_factory=list)
     output_intent: OutputIntent | None = None
     share_policy: SharePolicySummary | None = None
+    artifacts: list[ShareArtifactSummary] = Field(default_factory=list)
     summary: dict[str, int]
 
 

--- a/src/obsura_api/domain/studio.py
+++ b/src/obsura_api/domain/studio.py
@@ -6,7 +6,7 @@ import re
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from obsura_api.domain.common import TimestampedModel, UuidReference
+from obsura_api.domain.common import MetadataMap, TimestampedModel, UuidReference
 from obsura_api.domain.enums import ConfigurationKind, ContentType, MatcherKind
 from obsura_api.domain.pii import PIIDetectionOptions
 from obsura_api.domain.transforms import TransformationRule
@@ -137,7 +137,7 @@ class ConfigurationBase(BaseModel):
     default_image_transformation: TransformationRule | None = None
     pii_detection: PIIDetectionOptions | None = None
     face_preferences: dict[str, str | int | bool] = Field(default_factory=dict)
-    metadata: dict[str, str | int | bool | list[str]] = Field(default_factory=dict)
+    metadata: MetadataMap = Field(default_factory=dict)
 
 
 class ConfigurationCreate(ConfigurationBase):
@@ -160,7 +160,7 @@ class ConfigurationUpdate(BaseModel):
     default_image_transformation: TransformationRule | None = None
     pii_detection: PIIDetectionOptions | None = None
     face_preferences: dict[str, str | int | bool] | None = None
-    metadata: dict[str, str | int | bool | list[str]] | None = None
+    metadata: MetadataMap | None = None
 
 
 class ConfigurationRead(TimestampedModel, ConfigurationBase):

--- a/src/obsura_api/domain/workflows.py
+++ b/src/obsura_api/domain/workflows.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from obsura_api.domain.common import BoundingBox, UuidReference
-from obsura_api.domain.enums import ContentType, FindingKind, FindingSource, ReviewDecision
+from obsura_api.domain.common import BoundingBox, MetadataMap, UuidReference
+from obsura_api.domain.enums import (
+    ContentType,
+    FindingKind,
+    FindingSource,
+    OutputIntent,
+    ReviewDecision,
+)
 from obsura_api.domain.pii import PIIDetectionOptions
+from obsura_api.domain.sharing import SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 
 
@@ -45,7 +52,7 @@ class FindingRecord(BaseModel):
     confidence: float = Field(default=1.0, ge=0.0, le=1.0)
     decision: ReviewDecision = ReviewDecision.PENDING
     transformation: TransformationRule | None = None
-    metadata: dict[str, str | int | bool | list[str]] = Field(default_factory=dict)
+    metadata: MetadataMap = Field(default_factory=dict)
 
 
 class TextAnalysisRequest(BaseModel):
@@ -64,6 +71,7 @@ class TextAnalysisRequest(BaseModel):
     exact_values: list[str] = Field(default_factory=list)
     manual_spans: list[ManualTextSpan] = Field(default_factory=list)
     default_transformation: TransformationRule | None = None
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_job: bool = True
     persist_source_content: bool | None = None
 
@@ -118,6 +126,7 @@ class TextTransformRequest(BaseModel):
     finding_overrides: list[FindingOverride] = Field(default_factory=list)
     include_pending: bool = False
     default_transformation: TransformationRule | None = None
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_output: bool = True
 
     @model_validator(mode="after")
@@ -143,6 +152,8 @@ class TextTransformResponse(BaseModel):
     job_id: str | None = None
     output_text: str
     replacements: list[ReplacementRecord]
+    output_intent: OutputIntent = OutputIntent.PREVIEW
+    share_policy: SharePolicySummary | None = None
     summary: dict[str, int]
 
 
@@ -157,7 +168,7 @@ class ImageRegionInput(BaseModel):
     entity_name: str | None = None
     region: BoundingBox
     transformation: TransformationRule | None = None
-    metadata: dict[str, str | int | bool | list[str]] = Field(default_factory=dict)
+    metadata: MetadataMap = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def validate_kind(self) -> "ImageRegionInput":
@@ -187,6 +198,7 @@ class ImageWorkflowManifest(BaseModel):
     detect_text: bool = False
     detect_faces: bool = False
     default_transformation: TransformationRule | None = None
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_job: bool = True
     persist_source_content: bool | None = None
 
@@ -214,6 +226,8 @@ class ImageWorkflowResponse(BaseModel):
         default=None,
         description="Media URL derived from the storage-relative output reference.",
     )
+    output_intent: OutputIntent | None = None
+    share_policy: SharePolicySummary | None = None
     summary: dict[str, int]
 
 
@@ -241,4 +255,5 @@ class ImageJobTransformRequest(BaseModel):
     job_id: UuidReference
     finding_overrides: list[ImageFindingOverride] = Field(default_factory=list)
     include_pending: bool = False
+    output_intent: OutputIntent = OutputIntent.PREVIEW
     persist_output: bool = True

--- a/src/obsura_api/domain/workflows.py
+++ b/src/obsura_api/domain/workflows.py
@@ -13,7 +13,7 @@ from obsura_api.domain.enums import (
     ReviewDecision,
 )
 from obsura_api.domain.pii import PIIDetectionOptions
-from obsura_api.domain.sharing import SharePolicySummary
+from obsura_api.domain.sharing import ShareArtifactSummary, SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 
 
@@ -154,6 +154,7 @@ class TextTransformResponse(BaseModel):
     replacements: list[ReplacementRecord]
     output_intent: OutputIntent = OutputIntent.PREVIEW
     share_policy: SharePolicySummary | None = None
+    artifacts: list[ShareArtifactSummary] = Field(default_factory=list)
     summary: dict[str, int]
 
 
@@ -228,6 +229,7 @@ class ImageWorkflowResponse(BaseModel):
     )
     output_intent: OutputIntent | None = None
     share_policy: SharePolicySummary | None = None
+    artifacts: list[ShareArtifactSummary] = Field(default_factory=list)
     summary: dict[str, int]
 
 

--- a/src/obsura_api/services/csv_workflows.py
+++ b/src/obsura_api/services/csv_workflows.py
@@ -33,7 +33,12 @@ from obsura_api.services.detection import TextDetectionService
 from obsura_api.services.jobs import finding_to_schema
 from obsura_api.services.providers.pii import NoOpPIIDetector, PIIDetector
 from obsura_api.services.providers.text_anonymizer import NativeTextAnonymizer, TextAnonymizer
-from obsura_api.services.sharing import build_text_share_policy, share_metadata
+from obsura_api.services.sharing import (
+    build_csv_export_artifact,
+    build_csv_response_artifacts,
+    build_text_share_policy,
+    share_metadata,
+)
 from obsura_api.services.text_transformations import TextTransformationService
 from obsura_api.services.utils import hash_value, summarize_findings
 
@@ -156,6 +161,10 @@ class CSVWorkflowService:
             validate_cell_hash=False,
         )
         share_policy = build_text_share_policy(manifest.output_intent)
+        artifacts = build_csv_response_artifacts(
+            output_intent=manifest.output_intent,
+            share_policy=share_policy,
+        )
         if job_id is not None:
             self._persist_csv_output(
                 job_id=job_id,
@@ -167,6 +176,11 @@ class CSVWorkflowService:
                 has_header=resolved.parsed.has_header,
                 output_intent=manifest.output_intent,
                 share_policy=share_policy,
+                artifact=build_csv_export_artifact(
+                    output_intent=manifest.output_intent,
+                    share_policy=share_policy,
+                    primary=True,
+                ),
             )
 
         return CSVWorkflowResponse(
@@ -182,6 +196,7 @@ class CSVWorkflowService:
             replacements=replacements,
             output_intent=manifest.output_intent,
             share_policy=share_policy,
+            artifacts=artifacts,
             summary=self._transform_summary(replacements, formula_escape_count),
         )
 
@@ -213,6 +228,10 @@ class CSVWorkflowService:
 
         findings = [finding_to_schema(item) for item in job.findings]
         share_policy = build_text_share_policy(request.output_intent)
+        artifacts = build_csv_response_artifacts(
+            output_intent=request.output_intent,
+            share_policy=share_policy,
+        )
         output_rows, output_csv, replacements, formula_escape_count = self._apply_csv_findings(
             parsed=parsed,
             findings=findings,
@@ -233,6 +252,11 @@ class CSVWorkflowService:
                 has_header=parsed.has_header,
                 output_intent=request.output_intent,
                 share_policy=share_policy,
+                artifact=build_csv_export_artifact(
+                    output_intent=request.output_intent,
+                    share_policy=share_policy,
+                    primary=True,
+                ),
             )
 
         return CSVWorkflowResponse(
@@ -248,6 +272,7 @@ class CSVWorkflowService:
             replacements=replacements,
             output_intent=request.output_intent,
             share_policy=share_policy,
+            artifacts=artifacts,
             summary=self._transform_summary(replacements, formula_escape_count),
         )
 
@@ -638,6 +663,7 @@ class CSVWorkflowService:
         has_header: bool,
         output_intent,
         share_policy,
+        artifact,
     ) -> None:
         job = self.session.get(Job, job_id)
         if job is None:
@@ -654,7 +680,7 @@ class CSVWorkflowService:
                 "replacement_count": replacement_count,
                 "formula_escape_count": formula_escape_count,
                 "csv_has_header": has_header,
-                **share_metadata(output_intent, share_policy),
+                **share_metadata(output_intent, share_policy, artifact),
             },
         )
         self.session.add(output)

--- a/src/obsura_api/services/csv_workflows.py
+++ b/src/obsura_api/services/csv_workflows.py
@@ -33,6 +33,7 @@ from obsura_api.services.detection import TextDetectionService
 from obsura_api.services.jobs import finding_to_schema
 from obsura_api.services.providers.pii import NoOpPIIDetector, PIIDetector
 from obsura_api.services.providers.text_anonymizer import NativeTextAnonymizer, TextAnonymizer
+from obsura_api.services.sharing import build_text_share_policy, share_metadata
 from obsura_api.services.text_transformations import TextTransformationService
 from obsura_api.services.utils import hash_value, summarize_findings
 
@@ -154,6 +155,7 @@ class CSVWorkflowService:
             quotechar=manifest.quotechar,
             validate_cell_hash=False,
         )
+        share_policy = build_text_share_policy(manifest.output_intent)
         if job_id is not None:
             self._persist_csv_output(
                 job_id=job_id,
@@ -163,6 +165,8 @@ class CSVWorkflowService:
                 replacement_count=len(replacements),
                 formula_escape_count=formula_escape_count,
                 has_header=resolved.parsed.has_header,
+                output_intent=manifest.output_intent,
+                share_policy=share_policy,
             )
 
         return CSVWorkflowResponse(
@@ -176,6 +180,8 @@ class CSVWorkflowService:
             output_csv=output_csv,
             formula_escape_count=formula_escape_count,
             replacements=replacements,
+            output_intent=manifest.output_intent,
+            share_policy=share_policy,
             summary=self._transform_summary(replacements, formula_escape_count),
         )
 
@@ -206,6 +212,7 @@ class CSVWorkflowService:
             self._apply_override(stored_findings, override)
 
         findings = [finding_to_schema(item) for item in job.findings]
+        share_policy = build_text_share_policy(request.output_intent)
         output_rows, output_csv, replacements, formula_escape_count = self._apply_csv_findings(
             parsed=parsed,
             findings=findings,
@@ -224,6 +231,8 @@ class CSVWorkflowService:
                 replacement_count=len(replacements),
                 formula_escape_count=formula_escape_count,
                 has_header=parsed.has_header,
+                output_intent=request.output_intent,
+                share_policy=share_policy,
             )
 
         return CSVWorkflowResponse(
@@ -237,6 +246,8 @@ class CSVWorkflowService:
             output_csv=output_csv,
             formula_escape_count=formula_escape_count,
             replacements=replacements,
+            output_intent=request.output_intent,
+            share_policy=share_policy,
             summary=self._transform_summary(replacements, formula_escape_count),
         )
 
@@ -625,6 +636,8 @@ class CSVWorkflowService:
         replacement_count: int,
         formula_escape_count: int,
         has_header: bool,
+        output_intent,
+        share_policy,
     ) -> None:
         job = self.session.get(Job, job_id)
         if job is None:
@@ -641,6 +654,7 @@ class CSVWorkflowService:
                 "replacement_count": replacement_count,
                 "formula_escape_count": formula_escape_count,
                 "csv_has_header": has_header,
+                **share_metadata(output_intent, share_policy),
             },
         )
         self.session.add(output)

--- a/src/obsura_api/services/document_workflows.py
+++ b/src/obsura_api/services/document_workflows.py
@@ -37,6 +37,7 @@ from obsura_api.services.providers.documents import (
 )
 from obsura_api.services.providers.pii import NoOpPIIDetector, PIIDetector
 from obsura_api.services.providers.text_anonymizer import NativeTextAnonymizer, TextAnonymizer
+from obsura_api.services.sharing import build_text_share_policy, share_metadata
 from obsura_api.services.text_transformations import TextTransformationService
 from obsura_api.services.utils import hash_value, summarize_findings
 
@@ -144,12 +145,15 @@ class DocumentWorkflowService:
             default_transformation=resolved.default_transformation,
             validate_page_hash=False,
         )
+        share_policy = build_text_share_policy(manifest.output_intent)
         if job_id is not None:
             self._persist_document_output(
                 job_id=job_id,
                 output_text=output_text,
                 page_count=len(pages),
                 replacement_count=len(replacements),
+                output_intent=manifest.output_intent,
+                share_policy=share_policy,
             )
         return DocumentWorkflowResponse(
             job_id=job_id,
@@ -159,6 +163,8 @@ class DocumentWorkflowService:
             pages=pages,
             output_text=output_text,
             replacements=replacements,
+            output_intent=manifest.output_intent,
+            share_policy=share_policy,
             summary=self._transform_summary(replacements),
         )
 
@@ -182,6 +188,7 @@ class DocumentWorkflowService:
             self._apply_override(stored_findings, override)
 
         findings = [finding_to_schema(item) for item in job.findings]
+        share_policy = build_text_share_policy(request.output_intent)
         pages, output_text, replacements = self._apply_document_findings(
             pages=document.pages,
             findings=findings,
@@ -195,6 +202,8 @@ class DocumentWorkflowService:
                 output_text=output_text,
                 page_count=len(pages),
                 replacement_count=len(replacements),
+                output_intent=request.output_intent,
+                share_policy=share_policy,
             )
         return DocumentWorkflowResponse(
             job_id=job.id,
@@ -204,6 +213,8 @@ class DocumentWorkflowService:
             pages=pages,
             output_text=output_text,
             replacements=replacements,
+            output_intent=request.output_intent,
+            share_policy=share_policy,
             summary=self._transform_summary(replacements),
         )
 
@@ -412,6 +423,8 @@ class DocumentWorkflowService:
         output_text: str,
         page_count: int,
         replacement_count: int,
+        output_intent,
+        share_policy,
     ) -> None:
         job = self.session.get(Job, job_id)
         if job is None:
@@ -426,6 +439,7 @@ class DocumentWorkflowService:
                 "output_hash": hash_value(output_text),
                 "page_count": page_count,
                 "replacement_count": replacement_count,
+                **share_metadata(output_intent, share_policy),
             },
         )
         self.session.add(output)

--- a/src/obsura_api/services/document_workflows.py
+++ b/src/obsura_api/services/document_workflows.py
@@ -37,7 +37,11 @@ from obsura_api.services.providers.documents import (
 )
 from obsura_api.services.providers.pii import NoOpPIIDetector, PIIDetector
 from obsura_api.services.providers.text_anonymizer import NativeTextAnonymizer, TextAnonymizer
-from obsura_api.services.sharing import build_text_share_policy, share_metadata
+from obsura_api.services.sharing import (
+    build_document_artifact,
+    build_text_share_policy,
+    share_metadata,
+)
 from obsura_api.services.text_transformations import TextTransformationService
 from obsura_api.services.utils import hash_value, summarize_findings
 
@@ -146,6 +150,10 @@ class DocumentWorkflowService:
             validate_page_hash=False,
         )
         share_policy = build_text_share_policy(manifest.output_intent)
+        artifact = build_document_artifact(
+            output_intent=manifest.output_intent,
+            share_policy=share_policy,
+        )
         if job_id is not None:
             self._persist_document_output(
                 job_id=job_id,
@@ -154,6 +162,7 @@ class DocumentWorkflowService:
                 replacement_count=len(replacements),
                 output_intent=manifest.output_intent,
                 share_policy=share_policy,
+                artifact=artifact,
             )
         return DocumentWorkflowResponse(
             job_id=job_id,
@@ -165,6 +174,7 @@ class DocumentWorkflowService:
             replacements=replacements,
             output_intent=manifest.output_intent,
             share_policy=share_policy,
+            artifacts=[artifact],
             summary=self._transform_summary(replacements),
         )
 
@@ -189,6 +199,10 @@ class DocumentWorkflowService:
 
         findings = [finding_to_schema(item) for item in job.findings]
         share_policy = build_text_share_policy(request.output_intent)
+        artifact = build_document_artifact(
+            output_intent=request.output_intent,
+            share_policy=share_policy,
+        )
         pages, output_text, replacements = self._apply_document_findings(
             pages=document.pages,
             findings=findings,
@@ -204,6 +218,7 @@ class DocumentWorkflowService:
                 replacement_count=len(replacements),
                 output_intent=request.output_intent,
                 share_policy=share_policy,
+                artifact=artifact,
             )
         return DocumentWorkflowResponse(
             job_id=job.id,
@@ -215,6 +230,7 @@ class DocumentWorkflowService:
             replacements=replacements,
             output_intent=request.output_intent,
             share_policy=share_policy,
+            artifacts=[artifact],
             summary=self._transform_summary(replacements),
         )
 
@@ -425,6 +441,7 @@ class DocumentWorkflowService:
         replacement_count: int,
         output_intent,
         share_policy,
+        artifact,
     ) -> None:
         job = self.session.get(Job, job_id)
         if job is None:
@@ -439,7 +456,7 @@ class DocumentWorkflowService:
                 "output_hash": hash_value(output_text),
                 "page_count": page_count,
                 "replacement_count": replacement_count,
-                **share_metadata(output_intent, share_policy),
+                **share_metadata(output_intent, share_policy, artifact),
             },
         )
         self.session.add(output)

--- a/src/obsura_api/services/image_workflows.py
+++ b/src/obsura_api/services/image_workflows.py
@@ -48,6 +48,7 @@ from obsura_api.services.providers.faces import FaceDetector
 from obsura_api.services.providers.ocr import OCRBlock, OCRProvider
 from obsura_api.services.providers.pii import NoOpPIIDetector, PIIDetector
 from obsura_api.services.sharing import (
+    build_image_artifact,
     build_image_share_policy,
     resolve_image_transform_for_output_intent,
     share_metadata,
@@ -155,10 +156,17 @@ class ImageWorkflowService:
         source_file_path = None
         job_id = None
         stored_output = self.storage.save_image(image)
+        media_url = self.storage.media_url_for(stored_output)
         share_policy = build_image_share_policy(
             manifest.output_intent,
             security_rules_enforced=security_rules_enforced,
             auto_adjusted=auto_adjusted,
+        )
+        artifact = build_image_artifact(
+            output_intent=manifest.output_intent,
+            share_policy=share_policy,
+            output_file_path=stored_output,
+            media_url=media_url,
         )
         if manifest.persist_job:
             if self._should_persist_source_file(manifest):
@@ -177,6 +185,7 @@ class ImageWorkflowService:
                 output_file_path=str(stored_output),
                 output_intent=manifest.output_intent,
                 share_policy=share_policy,
+                artifact=artifact,
             )
 
         return ImageWorkflowResponse(
@@ -184,9 +193,10 @@ class ImageWorkflowService:
             findings=findings,
             stored_input_path=None,
             stored_output_path=stored_output,
-            media_url=self.storage.media_url_for(stored_output),
+            media_url=media_url,
             output_intent=manifest.output_intent,
             share_policy=share_policy,
+            artifacts=[artifact],
             summary=summarize_findings(findings),
         )
 
@@ -238,10 +248,17 @@ class ImageWorkflowService:
             self._apply_region(image, finding, resolved.rule)
 
         stored_output = self.storage.save_image(image, stem=f"{job.id}-reviewed")
+        media_url = self.storage.media_url_for(stored_output)
         share_policy = build_image_share_policy(
             request.output_intent,
             security_rules_enforced=security_rules_enforced,
             auto_adjusted=auto_adjusted,
+        )
+        artifact = build_image_artifact(
+            output_intent=request.output_intent,
+            share_policy=share_policy,
+            output_file_path=stored_output,
+            media_url=media_url,
         )
         if request.persist_output:
             job.status = JobStatus.TRANSFORMED
@@ -253,7 +270,7 @@ class ImageWorkflowService:
                 extra_data={
                     "source_output": "reviewed-job-transform",
                     "applied_finding_count": len(active_findings),
-                    **share_metadata(request.output_intent, share_policy),
+                    **share_metadata(request.output_intent, share_policy, artifact),
                 },
             )
             self.session.add(output)
@@ -264,9 +281,10 @@ class ImageWorkflowService:
             findings=findings,
             stored_input_path=None,
             stored_output_path=stored_output,
-            media_url=self.storage.media_url_for(stored_output),
+            media_url=media_url,
             output_intent=request.output_intent,
             share_policy=share_policy,
+            artifacts=[artifact],
             summary=summarize_findings(findings),
         )
 
@@ -791,6 +809,7 @@ class ImageWorkflowService:
         output_file_path: str | None = None,
         output_intent=None,
         share_policy: SharePolicySummary | None = None,
+        artifact=None,
     ) -> str:
         job = Job(
             title=title,
@@ -833,7 +852,7 @@ class ImageWorkflowService:
                 content_type=job.content_type,
                 output_file_path=output_file_path,
                 extra_data=(
-                    share_metadata(output_intent, share_policy)
+                    share_metadata(output_intent, share_policy, artifact)
                     if output_intent is not None and share_policy is not None
                     else {}
                 ),

--- a/src/obsura_api/services/image_workflows.py
+++ b/src/obsura_api/services/image_workflows.py
@@ -32,6 +32,7 @@ from obsura_api.domain.errors import (
     UnprocessableContentError,
     UnsupportedMediaTypeError,
 )
+from obsura_api.domain.sharing import SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import (
     FindingRecord,
@@ -46,6 +47,11 @@ from obsura_api.services.privacy import sanitize_persisted_finding_metadata
 from obsura_api.services.providers.faces import FaceDetector
 from obsura_api.services.providers.ocr import OCRBlock, OCRProvider
 from obsura_api.services.providers.pii import NoOpPIIDetector, PIIDetector
+from obsura_api.services.sharing import (
+    build_image_share_policy,
+    resolve_image_transform_for_output_intent,
+    share_metadata,
+)
 from obsura_api.services.storage import StorageService
 from obsura_api.services.studio import StudioService
 from obsura_api.services.utils import hash_value, preview_value, summarize_findings
@@ -131,15 +137,29 @@ class ImageWorkflowService:
         payload = self._sanitize_image_payload(file_bytes)
         image = payload.image.copy()
         findings = self._build_findings(payload.bytes, manifest, image_size=image.size)
+        security_rules_enforced = False
+        auto_adjusted = False
         for finding in findings:
             if finding.region is None:
                 continue
-            rule = finding.transformation or TransformationRule(mode=TransformationMode.BLUR)
-            self._apply_region(image, finding, rule)
+            resolved = resolve_image_transform_for_output_intent(
+                finding=finding,
+                finding_rule=finding.transformation,
+                default_rule=None,
+                output_intent=manifest.output_intent,
+            )
+            security_rules_enforced = security_rules_enforced or resolved.security_rules_enforced
+            auto_adjusted = auto_adjusted or resolved.auto_adjusted
+            self._apply_region(image, finding, resolved.rule)
 
         source_file_path = None
         job_id = None
         stored_output = self.storage.save_image(image)
+        share_policy = build_image_share_policy(
+            manifest.output_intent,
+            security_rules_enforced=security_rules_enforced,
+            auto_adjusted=auto_adjusted,
+        )
         if manifest.persist_job:
             if self._should_persist_source_file(manifest):
                 source_file_path = self.storage.save_upload(
@@ -155,6 +175,8 @@ class ImageWorkflowService:
                 findings=findings,
                 configuration_ids=manifest.configuration_ids,
                 output_file_path=str(stored_output),
+                output_intent=manifest.output_intent,
+                share_policy=share_policy,
             )
 
         return ImageWorkflowResponse(
@@ -163,6 +185,8 @@ class ImageWorkflowService:
             stored_input_path=None,
             stored_output_path=stored_output,
             media_url=self.storage.media_url_for(stored_output),
+            output_intent=manifest.output_intent,
+            share_policy=share_policy,
             summary=summarize_findings(findings),
         )
 
@@ -197,20 +221,28 @@ class ImageWorkflowService:
         self._validate_findings_within_bounds(findings, image.size)
         default_transformation = self._resolve_default_transformation(job.configuration_ids)
         active_findings = self._active_findings(findings, request.include_pending)
+        security_rules_enforced = False
+        auto_adjusted = False
 
         for finding in active_findings:
             if finding.region is None:
                 continue
-            rule = (
-                finding.transformation
-                or default_transformation
-                or TransformationRule(
-                    mode=TransformationMode.BLUR,
-                )
+            resolved = resolve_image_transform_for_output_intent(
+                finding=finding,
+                finding_rule=finding.transformation,
+                default_rule=default_transformation,
+                output_intent=request.output_intent,
             )
-            self._apply_region(image, finding, rule)
+            security_rules_enforced = security_rules_enforced or resolved.security_rules_enforced
+            auto_adjusted = auto_adjusted or resolved.auto_adjusted
+            self._apply_region(image, finding, resolved.rule)
 
         stored_output = self.storage.save_image(image, stem=f"{job.id}-reviewed")
+        share_policy = build_image_share_policy(
+            request.output_intent,
+            security_rules_enforced=security_rules_enforced,
+            auto_adjusted=auto_adjusted,
+        )
         if request.persist_output:
             job.status = JobStatus.TRANSFORMED
             job.summary = summarize_findings(findings)
@@ -221,6 +253,7 @@ class ImageWorkflowService:
                 extra_data={
                     "source_output": "reviewed-job-transform",
                     "applied_finding_count": len(active_findings),
+                    **share_metadata(request.output_intent, share_policy),
                 },
             )
             self.session.add(output)
@@ -232,6 +265,8 @@ class ImageWorkflowService:
             stored_input_path=None,
             stored_output_path=stored_output,
             media_url=self.storage.media_url_for(stored_output),
+            output_intent=request.output_intent,
+            share_policy=share_policy,
             summary=summarize_findings(findings),
         )
 
@@ -406,7 +441,7 @@ class ImageWorkflowService:
         self,
         raw_transformation: TransformationRule | None,
         default_transformation: TransformationRule | None,
-    ) -> TransformationRule:
+    ) -> TransformationRule | None:
         if raw_transformation is not None and raw_transformation.mode in {
             TransformationMode.MASK,
             TransformationMode.BLUR,
@@ -417,7 +452,7 @@ class ImageWorkflowService:
             return raw_transformation
         if default_transformation is not None:
             return default_transformation
-        return TransformationRule(mode=TransformationMode.BLUR)
+        return None
 
     def _combine_regions(self, regions: Iterable[BoundingBox]) -> BoundingBox:
         items = list(regions)
@@ -754,6 +789,8 @@ class ImageWorkflowService:
         findings: list[FindingRecord],
         configuration_ids: list[str],
         output_file_path: str | None = None,
+        output_intent=None,
+        share_policy: SharePolicySummary | None = None,
     ) -> str:
         job = Job(
             title=title,
@@ -795,7 +832,11 @@ class ImageWorkflowService:
                 job_id=job.id,
                 content_type=job.content_type,
                 output_file_path=output_file_path,
-                extra_data={},
+                extra_data=(
+                    share_metadata(output_intent, share_policy)
+                    if output_intent is not None and share_policy is not None
+                    else {}
+                ),
             )
             self.session.add(output)
 

--- a/src/obsura_api/services/jobs.py
+++ b/src/obsura_api/services/jobs.py
@@ -17,6 +17,7 @@ from obsura_api.domain.errors import NotFoundError
 from obsura_api.domain.jobs import JobOutputRecord, JobRead, JobReviewRequest
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingRecord
+from obsura_api.services.sharing import artifact_from_metadata
 from obsura_api.services.storage import StorageService
 from obsura_api.services.utils import summarize_findings
 
@@ -67,6 +68,11 @@ def output_to_schema(
         output_text=output.output_text,
         output_file_path=output_file_path,
         media_url=media_url,
+        artifact=artifact_from_metadata(
+            output.extra_data,
+            output_file_path=output_file_path,
+            media_url=media_url,
+        ),
         metadata=output.extra_data,
     )
 

--- a/src/obsura_api/services/sharing.py
+++ b/src/obsura_api/services/sharing.py
@@ -1,0 +1,115 @@
+"""Helpers for output-intent policy enforcement and metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from obsura_api.domain.enums import FindingSource, OutputIntent, TransformationMode
+from obsura_api.domain.errors import UnprocessableContentError
+from obsura_api.domain.sharing import SharePolicySummary
+from obsura_api.domain.transforms import TransformationRule
+from obsura_api.domain.workflows import FindingRecord
+
+SAFE_SHARE_TEXT_NOTE = (
+    "safe_share returns transformed text content rather than visually obscured text."
+)
+SAFE_SHARE_IMAGE_TEXT_NOTE = (
+    "safe_share does not allow blur or pixelation for OCR or text-derived image findings."
+)
+PRESENTATION_ONLY_TEXT_IMAGE_MODES = {
+    TransformationMode.BLUR,
+    TransformationMode.PIXELATE,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedImageShareTransform:
+    """Resolved image transform after applying output-intent policy."""
+
+    rule: TransformationRule
+    security_rules_enforced: bool = False
+    auto_adjusted: bool = False
+
+
+def build_text_share_policy(output_intent: OutputIntent) -> SharePolicySummary:
+    """Build policy metadata for text-bearing outputs."""
+
+    if output_intent is OutputIntent.SAFE_SHARE:
+        return SharePolicySummary(
+            output_intent=output_intent,
+            security_rules_enforced=True,
+            notes=[SAFE_SHARE_TEXT_NOTE],
+        )
+    return SharePolicySummary(output_intent=output_intent)
+
+
+def build_image_share_policy(
+    output_intent: OutputIntent,
+    *,
+    security_rules_enforced: bool,
+    auto_adjusted: bool,
+) -> SharePolicySummary:
+    """Build policy metadata for image outputs."""
+
+    notes: list[str] = []
+    if security_rules_enforced:
+        notes.append(SAFE_SHARE_IMAGE_TEXT_NOTE)
+    return SharePolicySummary(
+        output_intent=output_intent,
+        security_rules_enforced=security_rules_enforced,
+        auto_adjusted=auto_adjusted,
+        notes=notes,
+    )
+
+
+def share_metadata(
+    output_intent: OutputIntent,
+    share_policy: SharePolicySummary,
+) -> dict[str, object]:
+    """Serialize share metadata for persisted output records."""
+
+    return {
+        "output_intent": output_intent.value,
+        "share_policy": share_policy.model_dump(mode="json"),
+    }
+
+
+def resolve_image_transform_for_output_intent(
+    *,
+    finding: FindingRecord,
+    finding_rule: TransformationRule | None,
+    default_rule: TransformationRule | None,
+    output_intent: OutputIntent,
+) -> ResolvedImageShareTransform:
+    """Resolve the final image rule for one finding under the requested output intent."""
+
+    resolved_rule = finding_rule or default_rule
+    explicit_rule = resolved_rule is not None
+    if resolved_rule is None:
+        resolved_rule = TransformationRule(mode=TransformationMode.BLUR)
+
+    if output_intent is not OutputIntent.SAFE_SHARE or not is_text_derived_image_finding(finding):
+        return ResolvedImageShareTransform(rule=resolved_rule)
+
+    if resolved_rule.mode in PRESENTATION_ONLY_TEXT_IMAGE_MODES:
+        if explicit_rule:
+            raise UnprocessableContentError(
+                "safe_share does not allow blur or pixelation for OCR or "
+                "text-derived findings. Use overlay or another destructive visual transform.",
+            )
+        return ResolvedImageShareTransform(
+            rule=TransformationRule(mode=TransformationMode.OVERLAY),
+            security_rules_enforced=True,
+            auto_adjusted=True,
+        )
+
+    return ResolvedImageShareTransform(
+        rule=resolved_rule,
+        security_rules_enforced=True,
+    )
+
+
+def is_text_derived_image_finding(finding: FindingRecord) -> bool:
+    """Return whether an image finding originates from detected text."""
+
+    return finding.source is FindingSource.OCR or bool(finding.metadata.get("ocr_text_hash"))

--- a/src/obsura_api/services/sharing.py
+++ b/src/obsura_api/services/sharing.py
@@ -3,10 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Mapping
 
-from obsura_api.domain.enums import FindingSource, OutputIntent, TransformationMode
+from obsura_api.domain.enums import (
+    FindingSource,
+    OutputIntent,
+    ShareArtifactChannel,
+    ShareArtifactKind,
+    TransformationMode,
+)
 from obsura_api.domain.errors import UnprocessableContentError
-from obsura_api.domain.sharing import SharePolicySummary
+from obsura_api.domain.sharing import ShareArtifactSummary, SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import FindingRecord
 
@@ -16,6 +23,8 @@ SAFE_SHARE_TEXT_NOTE = (
 SAFE_SHARE_IMAGE_TEXT_NOTE = (
     "safe_share does not allow blur or pixelation for OCR or text-derived image findings."
 )
+CSV_EXPORT_NOTE = "Use output_csv for spreadsheet-safe export and external sharing."
+CSV_PREVIEW_NOTE = "Use output_rows for review UI only."
 PRESENTATION_ONLY_TEXT_IMAGE_MODES = {
     TransformationMode.BLUR,
     TransformationMode.PIXELATE,
@@ -65,13 +74,183 @@ def build_image_share_policy(
 def share_metadata(
     output_intent: OutputIntent,
     share_policy: SharePolicySummary,
+    artifact: ShareArtifactSummary | None = None,
 ) -> dict[str, object]:
     """Serialize share metadata for persisted output records."""
 
-    return {
+    metadata: dict[str, object] = {
         "output_intent": output_intent.value,
         "share_policy": share_policy.model_dump(mode="json"),
     }
+    if artifact is not None:
+        metadata["artifact"] = artifact.model_dump(
+            mode="json",
+            exclude={"output_file_path", "media_url"},
+            exclude_none=True,
+        )
+    return metadata
+
+
+def build_text_artifact(
+    *,
+    output_intent: OutputIntent,
+    share_policy: SharePolicySummary,
+    filename: str = "obsura-output.txt",
+    primary: bool = True,
+) -> ShareArtifactSummary:
+    """Build the primary artifact descriptor for text-like outputs."""
+
+    return ShareArtifactSummary(
+        name="output_text",
+        kind=ShareArtifactKind.TEXT,
+        channel=ShareArtifactChannel.INLINE,
+        intended_use=output_intent,
+        share_ready=output_intent is OutputIntent.SAFE_SHARE,
+        primary=primary,
+        filename=filename,
+        notes=list(share_policy.notes),
+    )
+
+
+def build_structured_artifact(
+    *,
+    output_intent: OutputIntent,
+    share_policy: SharePolicySummary,
+    primary: bool = True,
+) -> ShareArtifactSummary:
+    """Build the primary artifact descriptor for structured JSON outputs."""
+
+    return ShareArtifactSummary(
+        name="output_data",
+        kind=ShareArtifactKind.JSON,
+        channel=ShareArtifactChannel.INLINE,
+        intended_use=output_intent,
+        share_ready=output_intent is OutputIntent.SAFE_SHARE,
+        primary=primary,
+        filename="obsura-output.json",
+        notes=list(share_policy.notes),
+    )
+
+
+def build_document_artifact(
+    *,
+    output_intent: OutputIntent,
+    share_policy: SharePolicySummary,
+    primary: bool = True,
+) -> ShareArtifactSummary:
+    """Build the primary artifact descriptor for document text outputs."""
+
+    return ShareArtifactSummary(
+        name="output_text",
+        kind=ShareArtifactKind.TEXT,
+        channel=ShareArtifactChannel.INLINE,
+        intended_use=output_intent,
+        share_ready=output_intent is OutputIntent.SAFE_SHARE,
+        primary=primary,
+        filename="obsura-document.txt",
+        notes=list(share_policy.notes),
+    )
+
+
+def build_csv_export_artifact(
+    *,
+    output_intent: OutputIntent,
+    share_policy: SharePolicySummary,
+    primary: bool,
+) -> ShareArtifactSummary:
+    """Build the downloadable CSV export artifact descriptor."""
+
+    notes = list(share_policy.notes)
+    if CSV_EXPORT_NOTE not in notes:
+        notes.append(CSV_EXPORT_NOTE)
+    return ShareArtifactSummary(
+        name="output_csv",
+        kind=ShareArtifactKind.CSV_EXPORT,
+        channel=ShareArtifactChannel.DOWNLOAD,
+        intended_use=OutputIntent.SAFE_SHARE,
+        share_ready=True,
+        primary=primary,
+        filename="obsura-output.csv",
+        notes=notes,
+    )
+
+
+def build_csv_preview_artifact(*, primary: bool) -> ShareArtifactSummary:
+    """Build the inline CSV preview artifact descriptor."""
+
+    return ShareArtifactSummary(
+        name="output_rows",
+        kind=ShareArtifactKind.TABLE_PREVIEW,
+        channel=ShareArtifactChannel.INLINE,
+        intended_use=OutputIntent.PREVIEW,
+        share_ready=False,
+        primary=primary,
+        notes=[CSV_PREVIEW_NOTE],
+    )
+
+
+def build_csv_response_artifacts(
+    *,
+    output_intent: OutputIntent,
+    share_policy: SharePolicySummary,
+) -> list[ShareArtifactSummary]:
+    """Build response artifact descriptors for CSV transforms."""
+
+    preview_artifact = build_csv_preview_artifact(primary=output_intent is OutputIntent.PREVIEW)
+    export_artifact = build_csv_export_artifact(
+        output_intent=output_intent,
+        share_policy=share_policy,
+        primary=output_intent is OutputIntent.SAFE_SHARE,
+    )
+    if output_intent is OutputIntent.SAFE_SHARE:
+        return [export_artifact, preview_artifact]
+    return [preview_artifact, export_artifact]
+
+
+def build_image_artifact(
+    *,
+    output_intent: OutputIntent,
+    share_policy: SharePolicySummary,
+    output_file_path: str | None,
+    media_url: str | None,
+    primary: bool = True,
+) -> ShareArtifactSummary:
+    """Build the image artifact descriptor."""
+
+    return ShareArtifactSummary(
+        name="output_image",
+        kind=ShareArtifactKind.IMAGE,
+        channel=ShareArtifactChannel.MEDIA,
+        intended_use=output_intent,
+        share_ready=output_intent is OutputIntent.SAFE_SHARE,
+        primary=primary,
+        filename="obsura-output.png",
+        output_file_path=output_file_path,
+        media_url=media_url,
+        notes=list(share_policy.notes),
+    )
+
+
+def artifact_from_metadata(
+    metadata: Mapping[str, object] | None,
+    *,
+    output_file_path: str | None = None,
+    media_url: str | None = None,
+) -> ShareArtifactSummary | None:
+    """Parse a persisted artifact descriptor and attach runtime path information."""
+
+    if not metadata:
+        return None
+    raw_artifact = metadata.get("artifact")
+    if not isinstance(raw_artifact, dict):
+        return None
+    artifact = ShareArtifactSummary.model_validate(raw_artifact)
+    return artifact.model_copy(
+        update={
+            "output_file_path": output_file_path or artifact.output_file_path,
+            "media_url": media_url or artifact.media_url,
+        }
+    )
 
 
 def resolve_image_transform_for_output_intent(

--- a/src/obsura_api/services/structured_workflows.py
+++ b/src/obsura_api/services/structured_workflows.py
@@ -21,6 +21,7 @@ from obsura_api.domain.errors import (
     UnprocessableContentError,
 )
 from obsura_api.domain.pii import PIIDetectionOptions
+from obsura_api.domain.sharing import SharePolicySummary
 from obsura_api.domain.structured import (
     StructuredAnalysisRequest,
     StructuredJobTransformRequest,
@@ -34,6 +35,7 @@ from obsura_api.services.detection import TextDetectionService
 from obsura_api.services.jobs import finding_to_schema
 from obsura_api.services.providers.pii import NoOpPIIDetector, PIIDetector
 from obsura_api.services.providers.text_anonymizer import NativeTextAnonymizer, TextAnonymizer
+from obsura_api.services.sharing import build_text_share_policy, share_metadata
 from obsura_api.services.text_transformations import TextTransformationService
 from obsura_api.services.utils import hash_value, summarize_findings
 
@@ -128,10 +130,12 @@ class StructuredWorkflowService:
                 pii_detection=request.pii_detection,
                 exact_values=request.exact_values,
                 default_transformation=request.default_transformation,
+                output_intent=request.output_intent,
                 persist_job=request.persist_job,
                 persist_source_content=request.persist_source_content,
             ),
         )
+        share_policy = build_text_share_policy(request.output_intent)
         output_data, replacements = self._apply_structured_findings(
             data=request.data,
             findings=analysis.findings,
@@ -143,12 +147,16 @@ class StructuredWorkflowService:
                 job_id=analysis.job_id,
                 output_data=output_data,
                 replacement_count=len(replacements),
+                output_intent=request.output_intent,
+                share_policy=share_policy,
             )
         return StructuredWorkflowResponse(
             job_id=analysis.job_id,
             findings=analysis.findings,
             output_data=output_data,
             replacements=replacements,
+            output_intent=request.output_intent,
+            share_policy=share_policy,
             summary=self._transform_summary(replacements),
         )
 
@@ -165,6 +173,7 @@ class StructuredWorkflowService:
             self._apply_override(stored_findings, override)
 
         findings = [finding_to_schema(item) for item in job.findings]
+        share_policy = build_text_share_policy(request.output_intent)
         output_data, replacements = self._apply_structured_findings(
             data=request.data,
             findings=findings,
@@ -176,12 +185,16 @@ class StructuredWorkflowService:
                 job_id=job.id,
                 output_data=output_data,
                 replacement_count=len(replacements),
+                output_intent=request.output_intent,
+                share_policy=share_policy,
             )
         return StructuredWorkflowResponse(
             job_id=job.id,
             findings=findings,
             output_data=output_data,
             replacements=replacements,
+            output_intent=request.output_intent,
+            share_policy=share_policy,
             summary=self._transform_summary(replacements),
         )
 
@@ -464,6 +477,8 @@ class StructuredWorkflowService:
         job_id: str,
         output_data: dict[str, Any] | list[Any],
         replacement_count: int,
+        output_intent,
+        share_policy: SharePolicySummary,
     ) -> None:
         job = self.session.get(Job, job_id)
         if job is None:
@@ -480,6 +495,7 @@ class StructuredWorkflowService:
                 "replacement_count": replacement_count,
                 "output_hash": hash_value(output_json),
                 "structured_root_type": "array" if isinstance(output_data, list) else "object",
+                **share_metadata(output_intent, share_policy),
             },
         )
         self.session.add(output)

--- a/src/obsura_api/services/structured_workflows.py
+++ b/src/obsura_api/services/structured_workflows.py
@@ -35,7 +35,11 @@ from obsura_api.services.detection import TextDetectionService
 from obsura_api.services.jobs import finding_to_schema
 from obsura_api.services.providers.pii import NoOpPIIDetector, PIIDetector
 from obsura_api.services.providers.text_anonymizer import NativeTextAnonymizer, TextAnonymizer
-from obsura_api.services.sharing import build_text_share_policy, share_metadata
+from obsura_api.services.sharing import (
+    build_structured_artifact,
+    build_text_share_policy,
+    share_metadata,
+)
 from obsura_api.services.text_transformations import TextTransformationService
 from obsura_api.services.utils import hash_value, summarize_findings
 
@@ -136,6 +140,10 @@ class StructuredWorkflowService:
             ),
         )
         share_policy = build_text_share_policy(request.output_intent)
+        artifact = build_structured_artifact(
+            output_intent=request.output_intent,
+            share_policy=share_policy,
+        )
         output_data, replacements = self._apply_structured_findings(
             data=request.data,
             findings=analysis.findings,
@@ -149,6 +157,7 @@ class StructuredWorkflowService:
                 replacement_count=len(replacements),
                 output_intent=request.output_intent,
                 share_policy=share_policy,
+                artifact=artifact,
             )
         return StructuredWorkflowResponse(
             job_id=analysis.job_id,
@@ -157,6 +166,7 @@ class StructuredWorkflowService:
             replacements=replacements,
             output_intent=request.output_intent,
             share_policy=share_policy,
+            artifacts=[artifact],
             summary=self._transform_summary(replacements),
         )
 
@@ -174,6 +184,10 @@ class StructuredWorkflowService:
 
         findings = [finding_to_schema(item) for item in job.findings]
         share_policy = build_text_share_policy(request.output_intent)
+        artifact = build_structured_artifact(
+            output_intent=request.output_intent,
+            share_policy=share_policy,
+        )
         output_data, replacements = self._apply_structured_findings(
             data=request.data,
             findings=findings,
@@ -187,6 +201,7 @@ class StructuredWorkflowService:
                 replacement_count=len(replacements),
                 output_intent=request.output_intent,
                 share_policy=share_policy,
+                artifact=artifact,
             )
         return StructuredWorkflowResponse(
             job_id=job.id,
@@ -195,6 +210,7 @@ class StructuredWorkflowService:
             replacements=replacements,
             output_intent=request.output_intent,
             share_policy=share_policy,
+            artifacts=[artifact],
             summary=self._transform_summary(replacements),
         )
 
@@ -479,6 +495,7 @@ class StructuredWorkflowService:
         replacement_count: int,
         output_intent,
         share_policy: SharePolicySummary,
+        artifact,
     ) -> None:
         job = self.session.get(Job, job_id)
         if job is None:
@@ -495,7 +512,7 @@ class StructuredWorkflowService:
                 "replacement_count": replacement_count,
                 "output_hash": hash_value(output_json),
                 "structured_root_type": "array" if isinstance(output_data, list) else "object",
-                **share_metadata(output_intent, share_policy),
+                **share_metadata(output_intent, share_policy, artifact),
             },
         )
         self.session.add(output)

--- a/src/obsura_api/services/text_transformations.py
+++ b/src/obsura_api/services/text_transformations.py
@@ -13,10 +13,12 @@ from obsura_api.domain.enums import (
     ContentType,
     FindingSource,
     JobStatus,
+    OutputIntent,
     ReviewDecision,
     TransformationMode,
 )
 from obsura_api.domain.errors import BadRequestError, NotFoundError, UnprocessableContentError
+from obsura_api.domain.sharing import SharePolicySummary
 from obsura_api.domain.transforms import TransformationRule
 from obsura_api.domain.workflows import (
     FindingOverride,
@@ -27,6 +29,7 @@ from obsura_api.domain.workflows import (
 )
 from obsura_api.services.jobs import finding_to_schema
 from obsura_api.services.providers.text_anonymizer import NativeTextAnonymizer, TextAnonymizer
+from obsura_api.services.sharing import build_text_share_policy, share_metadata
 from obsura_api.services.utils import hash_value, normalize_token, summarize_findings
 
 SOURCE_PRIORITY = {
@@ -67,6 +70,8 @@ class TextTransformationService:
         job_id: str,
         output_text: str,
         replacement_count: int,
+        output_intent: OutputIntent = OutputIntent.PREVIEW,
+        share_policy: SharePolicySummary | None = None,
     ) -> None:
         """Persist a text output for an existing job."""
 
@@ -74,6 +79,7 @@ class TextTransformationService:
         if job is None:
             return
         job.status = JobStatus.TRANSFORMED
+        resolved_share_policy = share_policy or build_text_share_policy(output_intent)
         output = JobOutput(
             job_id=job.id,
             content_type=job.content_type,
@@ -81,6 +87,7 @@ class TextTransformationService:
             extra_data={
                 "replacement_count": replacement_count,
                 "output_hash": hash_value(output_text),
+                **share_metadata(output_intent, resolved_share_policy),
             },
         )
         self.session.add(output)
@@ -109,6 +116,7 @@ class TextTransformationService:
             )
 
         findings = [finding_to_schema(item) for item in job.findings]
+        share_policy = build_text_share_policy(request.output_intent)
         output_text, replacements = self.apply_findings(
             content=content,
             findings=findings,
@@ -126,6 +134,7 @@ class TextTransformationService:
                 extra_data={
                     "replacement_count": len(replacements),
                     "output_hash": hash_value(output_text),
+                    **share_metadata(request.output_intent, share_policy),
                 },
             )
             self.session.add(output)
@@ -136,6 +145,8 @@ class TextTransformationService:
             job_id=job.id,
             output_text=output_text,
             replacements=replacements,
+            output_intent=request.output_intent,
+            share_policy=share_policy,
             summary={"replacement_count": len(replacements)},
         )
 

--- a/src/obsura_api/services/text_transformations.py
+++ b/src/obsura_api/services/text_transformations.py
@@ -29,7 +29,7 @@ from obsura_api.domain.workflows import (
 )
 from obsura_api.services.jobs import finding_to_schema
 from obsura_api.services.providers.text_anonymizer import NativeTextAnonymizer, TextAnonymizer
-from obsura_api.services.sharing import build_text_share_policy, share_metadata
+from obsura_api.services.sharing import build_text_artifact, build_text_share_policy, share_metadata
 from obsura_api.services.utils import hash_value, normalize_token, summarize_findings
 
 SOURCE_PRIORITY = {
@@ -80,6 +80,10 @@ class TextTransformationService:
             return
         job.status = JobStatus.TRANSFORMED
         resolved_share_policy = share_policy or build_text_share_policy(output_intent)
+        artifact = build_text_artifact(
+            output_intent=output_intent,
+            share_policy=resolved_share_policy,
+        )
         output = JobOutput(
             job_id=job.id,
             content_type=job.content_type,
@@ -87,7 +91,7 @@ class TextTransformationService:
             extra_data={
                 "replacement_count": replacement_count,
                 "output_hash": hash_value(output_text),
-                **share_metadata(output_intent, resolved_share_policy),
+                **share_metadata(output_intent, resolved_share_policy, artifact),
             },
         )
         self.session.add(output)
@@ -117,6 +121,10 @@ class TextTransformationService:
 
         findings = [finding_to_schema(item) for item in job.findings]
         share_policy = build_text_share_policy(request.output_intent)
+        artifact = build_text_artifact(
+            output_intent=request.output_intent,
+            share_policy=share_policy,
+        )
         output_text, replacements = self.apply_findings(
             content=content,
             findings=findings,
@@ -134,7 +142,7 @@ class TextTransformationService:
                 extra_data={
                     "replacement_count": len(replacements),
                     "output_hash": hash_value(output_text),
-                    **share_metadata(request.output_intent, share_policy),
+                    **share_metadata(request.output_intent, share_policy, artifact),
                 },
             )
             self.session.add(output)
@@ -147,6 +155,7 @@ class TextTransformationService:
             replacements=replacements,
             output_intent=request.output_intent,
             share_policy=share_policy,
+            artifacts=[artifact],
             summary={"replacement_count": len(replacements)},
         )
 

--- a/src/obsura_api/tools/api_artifacts.py
+++ b/src/obsura_api/tools/api_artifacts.py
@@ -247,6 +247,7 @@ REQUEST_EXAMPLES: dict[tuple[str, str], dict[str, Any]] = {
             }
         ],
         "include_pending": False,
+        "output_intent": "safe_share",
         "persist_output": True,
     },
     ("POST", "/api/v1/workflows/text/analyze-transform"): {
@@ -296,6 +297,7 @@ REQUEST_EXAMPLES: dict[tuple[str, str], dict[str, Any]] = {
             }
         },
         "exact_values": ["secret"],
+        "output_intent": "safe_share",
         "persist_job": False,
     },
     ("POST", "/api/v1/workflows/structured/transform-job"): {
@@ -313,6 +315,7 @@ REQUEST_EXAMPLES: dict[tuple[str, str], dict[str, Any]] = {
             }
         ],
         "include_pending": False,
+        "output_intent": "safe_share",
         "persist_output": True,
     },
     ("POST", "/api/v1/workflows/documents/transform-job"): {
@@ -324,6 +327,7 @@ REQUEST_EXAMPLES: dict[tuple[str, str], dict[str, Any]] = {
             }
         ],
         "include_pending": False,
+        "output_intent": "safe_share",
         "persist_output": True,
     },
     ("POST", "/api/v1/workflows/images/transform-job"): {
@@ -342,6 +346,7 @@ REQUEST_EXAMPLES: dict[tuple[str, str], dict[str, Any]] = {
             }
         ],
         "include_pending": False,
+        "output_intent": "safe_share",
         "persist_output": True,
     },
 }
@@ -380,6 +385,7 @@ FORM_EXAMPLES: dict[tuple[str, str], dict[str, str]] = {
                 },
                 "apply_builtins": True,
                 "exact_values": ["secret"],
+                "output_intent": "safe_share",
                 "has_header": True,
                 "persist_job": True,
             },
@@ -397,6 +403,7 @@ FORM_EXAMPLES: dict[tuple[str, str], dict[str, str]] = {
                     }
                 ],
                 "include_pending": False,
+                "output_intent": "safe_share",
                 "persist_output": True,
             },
             indent=2,
@@ -434,6 +441,7 @@ FORM_EXAMPLES: dict[tuple[str, str], dict[str, str]] = {
                 },
                 "exact_values": ["secret"],
                 "apply_builtins": True,
+                "output_intent": "safe_share",
                 "persist_job": True,
             },
             indent=2,
@@ -450,6 +458,7 @@ FORM_EXAMPLES: dict[tuple[str, str], dict[str, str]] = {
                     }
                 ],
                 "include_pending": False,
+                "output_intent": "safe_share",
                 "persist_output": True,
             },
             indent=2,
@@ -470,6 +479,7 @@ FORM_EXAMPLES: dict[tuple[str, str], dict[str, str]] = {
                 },
                 "apply_builtins": True,
                 "detect_text": True,
+                "output_intent": "safe_share",
                 "regions": [
                     {
                         "kind": "image_region",

--- a/src/obsura_api/tools/api_artifacts.py
+++ b/src/obsura_api/tools/api_artifacts.py
@@ -949,7 +949,17 @@ def generate_artifacts(output_directory: Path | None = None) -> tuple[Path, Path
     target_directory = output_directory or Path.cwd()
     target_directory.mkdir(parents=True, exist_ok=True)
 
-    app = create_app(get_settings().model_copy(update={"auto_create_schema": True}))
+    settings = get_settings().model_copy(
+        update={
+            "auto_create_schema": True,
+            "database_url": "sqlite:///./data/obsura.db",
+            "ocr_backend": "noop",
+            "face_detector_backend": "noop",
+            "pii_backend": "noop",
+            "text_anonymizer_backend": "native",
+        }
+    )
+    app = create_app(settings)
     openapi_document = app.openapi()
     postman_collection = build_postman_collection(openapi_document)
 

--- a/tests/test_api_artifacts.py
+++ b/tests/test_api_artifacts.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from obsura_api.app import create_app
-from obsura_api.core.settings import Settings
-from obsura_api.tools.api_artifacts import build_postman_collection
+from obsura_api.core.settings import Settings, get_settings
+from obsura_api.tools.api_artifacts import build_postman_collection, generate_artifacts
 
 
 def test_postman_collection_uses_chained_variables() -> None:
@@ -133,3 +133,21 @@ def test_postman_collection_uses_chained_variables() -> None:
     assert "{{jobId}}" in document_transform_manifest_field["value"]
     assert "{{findingId}}" in document_transform_manifest_field["value"]
     assert '"output_intent": "safe_share"' in document_transform_manifest_field["value"]
+
+
+def test_generate_artifacts_ignores_heavy_runtime_backends(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://invalid:invalid@localhost/obsura")
+    monkeypatch.setenv("OBSURA_OCR_BACKEND", "tesseract")
+    monkeypatch.setenv("OBSURA_FACE_DETECTOR_BACKEND", "opencv")
+    monkeypatch.setenv("OBSURA_PII_BACKEND", "presidio")
+    get_settings.cache_clear()
+
+    openapi_path, postman_path = generate_artifacts(tmp_path)
+
+    assert openapi_path.exists()
+    assert postman_path.exists()
+    assert '"ShareArtifactSummary"' in openapi_path.read_text(encoding="utf-8")
+    get_settings.cache_clear()

--- a/tests/test_api_artifacts.py
+++ b/tests/test_api_artifacts.py
@@ -59,6 +59,7 @@ def test_postman_collection_uses_chained_variables() -> None:
     )
     assert "{{jobId}}" in transform_job_request["request"]["body"]["raw"]
     assert "{{findingId}}" in transform_job_request["request"]["body"]["raw"]
+    assert '"output_intent": "safe_share"' in transform_job_request["request"]["body"]["raw"]
 
     analyze_image_request = next(
         item for item in image_folder["item"] if item["name"] == "Analyze Image"
@@ -105,6 +106,7 @@ def test_postman_collection_uses_chained_variables() -> None:
     )
     assert "{{jobId}}" in csv_transform_manifest_field["value"]
     assert "{{findingId}}" in csv_transform_manifest_field["value"]
+    assert '"output_intent": "safe_share"' in csv_transform_manifest_field["value"]
 
     document_folder = next(
         item for item in collection["item"] if item["name"] == "Document Workflows"
@@ -130,3 +132,4 @@ def test_postman_collection_uses_chained_variables() -> None:
     )
     assert "{{jobId}}" in document_transform_manifest_field["value"]
     assert "{{findingId}}" in document_transform_manifest_field["value"]
+    assert '"output_intent": "safe_share"' in document_transform_manifest_field["value"]

--- a/tests/test_csv_workflows.py
+++ b/tests/test_csv_workflows.py
@@ -45,6 +45,11 @@ def test_csv_transform_masks_cells_and_escapes_formula_export(client) -> None:
     assert body["formula_escape_count"] == 1
     assert body["summary"]["replacement_count"] == 2
     assert body["summary"]["formula_escape_count"] == 1
+    assert body["artifacts"][0]["name"] == "output_rows"
+    assert body["artifacts"][0]["share_ready"] is False
+    assert body["artifacts"][1]["name"] == "output_csv"
+    assert body["artifacts"][1]["channel"] == "download"
+    assert body["artifacts"][1]["share_ready"] is True
 
 
 def test_csv_review_and_transform_job_flow(client) -> None:
@@ -83,6 +88,8 @@ def test_csv_review_and_transform_job_flow(client) -> None:
     transformed = transform_response.json()["data"]
     assert "[EMAIL]" in transformed["output_csv"]
     assert "[REDACTED]" in transformed["output_csv"]
+    assert transformed["artifacts"][0]["name"] == "output_rows"
+    assert transformed["artifacts"][1]["name"] == "output_csv"
 
     job_response = client.get(f"/api/v1/jobs/{job_id}")
     assert job_response.status_code == 200
@@ -91,6 +98,8 @@ def test_csv_review_and_transform_job_flow(client) -> None:
     assert job["source_text"] is None
     assert job["outputs"][0]["output_text"] is None
     assert job["outputs"][0]["metadata"]["formula_escape_count"] == 0
+    assert job["outputs"][0]["artifact"]["name"] == "output_csv"
+    assert job["outputs"][0]["artifact"]["channel"] == "download"
 
 
 def test_csv_transform_job_rejects_changed_cell_value(client) -> None:

--- a/tests/test_document_workflows.py
+++ b/tests/test_document_workflows.py
@@ -127,6 +127,9 @@ def test_document_transform_redacts_without_persisting_raw_pdf(document_client: 
     assert "[REDACTED]" in body["output_text"]
     assert body["pages"][0]["output_text"]
     assert body["summary"]["replacement_count"] == 2
+    assert body["artifacts"][0]["name"] == "output_text"
+    assert body["artifacts"][0]["kind"] == "text"
+    assert body["artifacts"][0]["primary"] is True
 
     job_response = document_client.get(f"/api/v1/jobs/{body['job_id']}")
     assert job_response.status_code == 200
@@ -135,6 +138,7 @@ def test_document_transform_redacts_without_persisting_raw_pdf(document_client: 
     assert job["source_file_path"] is None
     assert job["outputs"][0]["output_text"] is None
     assert job["outputs"][0]["metadata"]["document_kind"] == "pdf"
+    assert job["outputs"][0]["artifact"]["name"] == "output_text"
 
 
 def test_document_review_and_transform_job_requires_matching_pdf(

--- a/tests/test_image_workflows.py
+++ b/tests/test_image_workflows.py
@@ -412,6 +412,10 @@ def test_safe_share_image_transform_upgrades_implicit_ocr_blur_to_overlay(client
     assert body["output_intent"] == "safe_share"
     assert body["share_policy"]["security_rules_enforced"] is True
     assert body["share_policy"]["auto_adjusted"] is True
+    assert body["artifacts"][0]["name"] == "output_image"
+    assert body["artifacts"][0]["channel"] == "media"
+    assert body["artifacts"][0]["share_ready"] is True
+    assert body["artifacts"][0]["media_url"] == body["media_url"]
     transformed = _open_stored_image(client, body["stored_output_path"])
     assert transformed.getpixel((8, 5)) == (17, 17, 17)
 

--- a/tests/test_image_workflows.py
+++ b/tests/test_image_workflows.py
@@ -363,6 +363,113 @@ def test_ocr_derived_image_finding_can_be_reviewed_and_transformed(client) -> No
     assert transformed.getpixel((8, 5)) != (255, 255, 255)
 
 
+def test_safe_share_image_transform_upgrades_implicit_ocr_blur_to_overlay(client) -> None:
+    client.app.state.container.ocr_provider = FakeOCRProvider(
+        [
+            OCRBlock(
+                text="token alpha",
+                region=BoundingBox(x=0, y=0, width=12, height=10),
+                confidence=0.91,
+                tokens=[
+                    OCRToken(
+                        text="token",
+                        region=BoundingBox(x=0, y=0, width=5, height=10),
+                        confidence=0.91,
+                    ),
+                    OCRToken(
+                        text="alpha",
+                        region=BoundingBox(x=6, y=0, width=6, height=10),
+                        confidence=0.91,
+                    ),
+                ],
+            )
+        ]
+    )
+
+    image = Image.new("RGB", (20, 20), color="white")
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+
+    response = client.post(
+        "/api/v1/workflows/images/transform",
+        files={"file": ("ocr-safe-share.png", buffer.getvalue(), "image/png")},
+        data={
+            "manifest_json": json.dumps(
+                {
+                    "content_type": "screenshot",
+                    "detect_text": True,
+                    "apply_builtins": False,
+                    "exact_values": ["alpha"],
+                    "output_intent": "safe_share",
+                    "persist_job": False,
+                }
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["output_intent"] == "safe_share"
+    assert body["share_policy"]["security_rules_enforced"] is True
+    assert body["share_policy"]["auto_adjusted"] is True
+    transformed = _open_stored_image(client, body["stored_output_path"])
+    assert transformed.getpixel((8, 5)) == (17, 17, 17)
+
+
+def test_safe_share_image_transform_rejects_explicit_ocr_blur(client) -> None:
+    client.app.state.container.ocr_provider = FakeOCRProvider(
+        [
+            OCRBlock(
+                text="token alpha",
+                region=BoundingBox(x=0, y=0, width=12, height=10),
+                confidence=0.91,
+                tokens=[
+                    OCRToken(
+                        text="token",
+                        region=BoundingBox(x=0, y=0, width=5, height=10),
+                        confidence=0.91,
+                    ),
+                    OCRToken(
+                        text="alpha",
+                        region=BoundingBox(x=6, y=0, width=6, height=10),
+                        confidence=0.91,
+                    ),
+                ],
+            )
+        ]
+    )
+
+    image = Image.new("RGB", (20, 20), color="white")
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+
+    response = client.post(
+        "/api/v1/workflows/images/transform",
+        files={"file": ("ocr-safe-share.png", buffer.getvalue(), "image/png")},
+        data={
+            "manifest_json": json.dumps(
+                {
+                    "content_type": "screenshot",
+                    "detect_text": True,
+                    "apply_builtins": False,
+                    "exact_values": ["alpha"],
+                    "output_intent": "safe_share",
+                    "default_transformation": {
+                        "mode": "blur",
+                        "blur_radius": 12,
+                    },
+                    "persist_job": False,
+                }
+            )
+        },
+    )
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["success"] is False
+    assert "does not allow blur or pixelation" in body["error"]["message"]
+
+
 def test_persisted_image_job_hides_source_reference_and_raw_ocr_text(client) -> None:
     client.app.state.container.ocr_provider = FakeOCRProvider(
         [

--- a/tests/test_operational.py
+++ b/tests/test_operational.py
@@ -66,6 +66,7 @@ def test_ready_and_version_endpoints(client) -> None:
     assert version_body["data"]["pii_languages"] == []
     assert version_body["data"]["pii_custom_recognizers"] is False
     assert version_body["data"]["text_hash_supported"] is False
+    assert version_body["data"]["share_output_intents"] == ["preview", "safe_share"]
     assert version_body["data"]["ocr_available"] is False
     assert version_body["data"]["face_detection_available"] is False
     assert version_body["data"]["pii_available"] is False

--- a/tests/test_structured_workflows.py
+++ b/tests/test_structured_workflows.py
@@ -49,6 +49,8 @@ def test_structured_transform_masks_nested_values(client) -> None:
     body = response.json()["data"]
     assert body["output_data"]["patient"]["email"] == "[EMAIL]"
     assert body["output_data"]["audit"][0]["token"] == "[REDACTED]"
+    assert body["artifacts"][0]["name"] == "output_data"
+    assert body["artifacts"][0]["kind"] == "json"
     assert {item["path"] for item in body["replacements"]} == {
         "$.patient.email",
         "$.audit[0].token",
@@ -112,6 +114,7 @@ def test_structured_review_and_transform_job_flow(client) -> None:
     job = job_response.json()["data"]
     assert job["source_text"] is None
     assert job["outputs"][0]["output_text"] is None
+    assert job["outputs"][0]["artifact"]["name"] == "output_data"
     assert job["findings"][0]["metadata"]["structured_path"].startswith("$.customer")
 
 

--- a/tests/test_text_workflows.py
+++ b/tests/test_text_workflows.py
@@ -230,3 +230,48 @@ def test_text_transform_rejects_hash_mode_without_configured_salt(client) -> Non
     body = response.json()
     assert body["success"] is False
     assert "OBSURA_TEXT_HASH_SALT" in body["error"]["message"]
+
+
+def test_text_transform_safe_share_persists_output_intent_metadata(client) -> None:
+    analysis_response = client.post(
+        "/api/v1/workflows/text/analyze",
+        json={
+            "content": "token=alpha",
+            "exact_values": ["alpha"],
+            "persist_source_content": True,
+        },
+    )
+    assert analysis_response.status_code == 200
+    analysis = analysis_response.json()["data"]
+
+    review_response = client.post(
+        f"/api/v1/jobs/{analysis['job_id']}/review",
+        json={
+            "decisions": [
+                {
+                    "finding_id": analysis["findings"][0]["id"],
+                    "decision": "approved",
+                }
+            ]
+        },
+    )
+    assert review_response.status_code == 200
+
+    transform_response = client.post(
+        "/api/v1/workflows/text/transform",
+        json={
+            "job_id": analysis["job_id"],
+            "content": "token=alpha",
+            "output_intent": "safe_share",
+        },
+    )
+
+    assert transform_response.status_code == 200
+    body = transform_response.json()["data"]
+    assert body["output_intent"] == "safe_share"
+    assert body["share_policy"]["security_rules_enforced"] is True
+
+    job_response = client.get(f"/api/v1/jobs/{analysis['job_id']}")
+    assert job_response.status_code == 200
+    job = job_response.json()["data"]
+    assert job["outputs"][0]["metadata"]["output_intent"] == "safe_share"

--- a/tests/test_text_workflows.py
+++ b/tests/test_text_workflows.py
@@ -270,8 +270,14 @@ def test_text_transform_safe_share_persists_output_intent_metadata(client) -> No
     body = transform_response.json()["data"]
     assert body["output_intent"] == "safe_share"
     assert body["share_policy"]["security_rules_enforced"] is True
+    assert body["artifacts"][0]["name"] == "output_text"
+    assert body["artifacts"][0]["intended_use"] == "safe_share"
+    assert body["artifacts"][0]["share_ready"] is True
+    assert body["artifacts"][0]["primary"] is True
 
     job_response = client.get(f"/api/v1/jobs/{analysis['job_id']}")
     assert job_response.status_code == 200
     job = job_response.json()["data"]
     assert job["outputs"][0]["metadata"]["output_intent"] == "safe_share"
+    assert job["outputs"][0]["artifact"]["name"] == "output_text"
+    assert job["outputs"][0]["artifact"]["share_ready"] is True


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the Share model for `obsura-api`.

Phase 1 introduced `output_intent` and safe-share policy enforcement.  
Phase 2 makes produced outputs explicit by adding normalized artifact descriptors to transform responses and persisted job outputs.

## What changed

- added explicit `artifacts` to transform responses
- added explicit `artifact` to stored job output records
- introduced normalized artifact typing for:
  - inline text outputs
  - structured JSON outputs
  - CSV preview rows
  - CSV export artifacts
  - image/media outputs
- persisted output metadata now stores the primary artifact descriptor alongside `output_intent` and `share_policy`
- CSV responses now explicitly distinguish review-table output from export-ready CSV output
- image responses now explicitly describe the generated media artifact instead of relying only on `stored_output_path`
- made API artifact generation self-contained so `openapi.json` generation does not depend on local heavy runtime backends

## Why this matters

This makes `Share` more concrete in the API:

- the client can tell what artifact was produced
- the client can tell whether an artifact is preview-oriented or share-oriented
- stored job outputs now expose the same idea in a normalized way
- CSV now has a clean backend-level distinction between preview and export artifacts

## Security notes

- no raw sensitive persistence was reintroduced
- share policy enforcement from Phase 1 remains intact
- artifact metadata is descriptive only; it does not weaken existing transform restrictions
- safe-share image rules for OCR/text-derived findings remain enforced server-side

## Validation

Executed successfully:

```bash
python -m ruff format --check src tests
python -m mypy
python -m pytest -q
python -m obsura_api.tools.api_artifacts
```

Result:

```text
113 passed
```

JUST A REMINDER:
Next branch:
`feat/studio-versioning-import-export`
